### PR TITLE
AWS Batch: automated run directory creation and upload to s3 for GCHP

### DIFF
--- a/benchmarks/Dockerfile
+++ b/benchmarks/Dockerfile
@@ -4,5 +4,12 @@ COPY createRunDir.sh /createRunDir.sh
 COPY gchp_source.env gchp_source.env
 RUN chmod +x /createRunDir.sh \
     && apt-get update \
-    && apt-get install less
+    && apt-get install -y \
+        python3 \
+        python3-pip \
+        python3-setuptools \
+    && pip3 install --upgrade pip \
+    && apt-get clean
+
+RUN pip3 --no-cache-dir install --upgrade awscli
 ENTRYPOINT [ "./createRunDir.sh" ]

--- a/benchmarks/createRunDir.sh
+++ b/benchmarks/createRunDir.sh
@@ -15,7 +15,11 @@ EOF
 cat "run_input.txt" | ./createRunDir.sh
 mkdir /gc-src/build
 cd /gc-src/build
+# NOTE: doesn't work on m1 macbook air due to an issue with qemu
 cmake /gc-src
-cmake . -DRUNDIR="../../gc_default_rundir"
+cmake . -DRUNDIR="../../home/gc_default_rundir"
 make -j
 make -j install
+echo "starting run directory upload"
+aws s3 cp /home/gc_default_rundir $S3_RUNDIR_PATH --recursive --quiet
+echo "Finished run directory upload"

--- a/deploy/main.tf
+++ b/deploy/main.tf
@@ -91,7 +91,7 @@ module "gchp_image_builder" {
     component_name = "InstallSpackEnvironment"
     name_prefix = "spackenv"
     component_platform = "Linux"
-    component_version = "1.0.1"
+    builder_version = "1.0.2" # TODO: figure out a way to stop needing to change this with every update 
     component_file = "../../modules/ec2-image-builder/components/install-spack-component.yaml"
     security_group_id = module.benchmarks_security_group.security_group_id
     subnet_id = tolist(data.aws_subnet_ids.all_default_subnets.ids)[0]

--- a/deploy/main.tf
+++ b/deploy/main.tf
@@ -46,10 +46,14 @@ module "benchmarks_bucket" {
     enable_versioning = false
 }
 
+# ==============================================================
+# benchmark items
+# ==============================================================
 module "benchmarks_ecr_repository" { # could potentially make public to save on cost
     source = "./modules/ecr"
     repository_name ="${var.benchmarks_name_prefix}-repository"
 }
+
 module "batch_benchmark_artifacts" {
     source = "./modules/batch"
     name_prefix = var.benchmarks_name_prefix
@@ -64,8 +68,12 @@ module "batch_benchmark_artifacts" {
     container_properties_file = "../../modules/batch/container-properties/container-properties.json"
     region = data.aws_region.current.name
     log_retention_days = 1
+    s3_path = "s3://${var.benchmarks_bucket}" 
 }
 
+# ==============================================================
+# input data sync items
+# ==============================================================
 module "data_sync_ecr_repository" { # could potentially make public to save on cost
     source = "./modules/ecr"
     repository_name = "input-data-sync-repository"
@@ -84,8 +92,12 @@ module "batch_data_sync_artifacts" {
     container_properties_file = "../../modules/batch/container-properties/container-properties.json"
     region = data.aws_region.current.name
     log_retention_days = 1
+    s3_path = "s3://${var.benchmarks_bucket}" # TODO: update batch module to be more flexible 
 }
 
+# ==============================================================
+# image builder items
+# ==============================================================
 module "gchp_image_builder" {
     source = "./modules/ec2-image-builder"
     component_name = "InstallSpackEnvironment"

--- a/deploy/modules/batch/batch-module.tf
+++ b/deploy/modules/batch/batch-module.tf
@@ -9,7 +9,9 @@ resource "aws_batch_compute_environment" "batch_environment" {
             var.security_group_id
         ]
         subnets = var.subnet_ids
-        type = "EC2"
+        type = "SPOT"
+        # TODO: make a variable
+        spot_iam_fleet_role = "arn:aws:iam::753979222379:role/aws-service-role/spotfleet.amazonaws.com/AWSServiceRoleForEC2SpotFleet"
     }
     service_role = aws_iam_role.batch_role.arn
     type = "MANAGED"
@@ -49,6 +51,7 @@ data "template_file" "container_properties" {
         job_role = aws_iam_role.job_role.arn
         log_group = var.name_prefix
         log_name = "${var.name_prefix}-batch-job"
+        s3_path = var.s3_path
     }
 }
 

--- a/deploy/modules/batch/container-properties/container-properties.json
+++ b/deploy/modules/batch/container-properties/container-properties.json
@@ -1,6 +1,11 @@
 { 
     "command": [],
-    "environment": [],
+    "environment": [
+        { 
+            "name": "S3_RUNDIR_PATH",
+            "value": "${s3_path}/rundir/"
+        }
+    ],
     "image": "${docker_image}",
     "jobRoleArn": "${job_role}",
     "logConfiguration": {

--- a/deploy/modules/batch/roles.tf
+++ b/deploy/modules/batch/roles.tf
@@ -25,7 +25,6 @@ resource "aws_iam_role_policy_attachment" "batch_policy_attachment" {
     role = aws_iam_role.batch_role.name
     policy_arn = "arn:aws:iam::aws:policy/service-role/AWSBatchServiceRole"
 }
-
 # Role for underlying EC2 instances
 resource "aws_iam_role" "ec2_role" {
     name = "${var.name_prefix}-ec2-role"

--- a/deploy/modules/batch/variables.tf
+++ b/deploy/modules/batch/variables.tf
@@ -34,3 +34,6 @@ variable "region" {
 variable "log_retention_days" {
     description = "number of days to retain logs in cloudwatch"
 }
+variable "s3_path" {
+    description = "path to upload run directory to"
+}

--- a/deploy/modules/ec2-image-builder/variables.tf
+++ b/deploy/modules/ec2-image-builder/variables.tf
@@ -4,7 +4,7 @@ variable component_file {
 variable component_name {
     description = "name of the component"
 }
-variable component_version {
+variable builder_version {
     description = "which component version you are using (eg. 1.0)"
 }
 variable component_platform {


### PR DESCRIPTION
This PR includes a few changes that get a basic working version of automated run directory creation, compilation, and upload to an s3 bucket ( defined by an env variable that can be updated on job creation). I wanted to get these changes in so that @LiamBindle would have a basic pattern to follow for his input data sync workflow, as I need to switch gears for a day or two to a different project. There is also a small fix that improves updating ec2 image builder components/ recipes.
That being said there are a few TODO's still left for this including:
- adding an env variable to select a tag or commit hash to checkout a specific version of GCHP
- add options for updating config files to non standard defaults

Next up for this workflow will be:
- a step that downloads the input data and runs the model on a single node, uploading output to s3
- Extending the above step to use multinode batch configurations