### PR TITLE
Added aqacf bucket and a few updates

### DIFF
--- a/deploy/environments/harvard/harvard.tf
+++ b/deploy/environments/harvard/harvard.tf
@@ -27,4 +27,5 @@ module "harvard" {
     source = "../.."
     benchmarks_bucket = "benchmarks-cloud"
     benchmarks_name_prefix = "benchmarks-cloud"
+    organization = "harvard"
 }

--- a/deploy/environments/washu/washu.tf
+++ b/deploy/environments/washu/washu.tf
@@ -24,4 +24,5 @@ module "washu" {
     source = "../.."
     benchmarks_bucket = "washu-benchmarks-cloud"
     benchmarks_name_prefix = "washu-benchmarks-cloud"
+    organization = "washu"
 }

--- a/deploy/main.tf
+++ b/deploy/main.tf
@@ -17,6 +17,19 @@ terraform {
         }
     }
 }
+
+# ==============================================================
+# local variables 
+# ==============================================================
+locals {
+    # variables used to determine if a module should only be for 
+    # one organization
+    only_washu = var.organization == "washu" ? 1 : 0
+    only_harvard = var.organization == "harvard" ? 1 : 0
+    AQACF_account_number = "" #TODO replace with real account #
+}
+
+
 # ==============================================================
 # vpc items -- TODO: for now using default vpc and subnets, 
 # but may be good to create purpose built vpc
@@ -108,4 +121,36 @@ module "gchp_image_builder" {
     security_group_id = module.benchmarks_security_group.security_group_id
     subnet_id = tolist(data.aws_subnet_ids.all_default_subnets.ids)[0]
     recipe_name = "geoschem_deps-pcluster_ami-x86_64-alinux2-intel_latest-intelmpi_latest"
+}
+
+# ==============================================================
+# AQACF items
+# ==============================================================
+module "AQACF_bucket" {
+    source = "./modules/s3/bucket"
+    count = local.only_washu
+    bucket_name = "${var.organization}-aqacf-data"
+    enable_versioning = false
+    bucket_policy = <<POLICY
+{
+   "Version": "2012-10-17",
+   "Statement": [
+      {
+         "Sid": "AQACF permissions",
+         "Effect": "Allow",
+         "Principal": {
+            "AWS": "arn:aws:iam::${local.AQACF_account_number}:root"
+         },
+         "Action": [
+            "s3:GetBucketLocation",
+            "s3:ListBucket",
+            "s3:GetObject"
+         ],
+         "Resource": [
+            "arn:aws:s3:::${var.organization}-aqacf-data"
+         ]
+      }
+   ]
+}
+POLICY
 }

--- a/deploy/modules/s3/bucket/s3-module.tf
+++ b/deploy/modules/s3/bucket/s3-module.tf
@@ -2,6 +2,7 @@ resource "aws_s3_bucket" "bucket" {
     bucket = var.bucket_name
 
     acl = var.bucket_acl
+    policy = var.bucket_policy
     versioning {
         enabled = var.enable_versioning
     }

--- a/deploy/modules/s3/bucket/variables.tf
+++ b/deploy/modules/s3/bucket/variables.tf
@@ -4,6 +4,11 @@ variable bucket_name {
 
 variable bucket_acl {
     description = "The canned ACL to apply. Valid values are private, public-read, public-read-write, aws-exec-read, authenticated-read, and log-delivery-write."
+    default = null
+}
+variable bucket_policy {
+    description = "json policy for bucket"
+    default = null
 }
 
 variable enable_versioning {

--- a/deploy/variables.tf
+++ b/deploy/variables.tf
@@ -4,3 +4,6 @@ variable benchmarks_bucket {
 variable benchmarks_name_prefix {
   description = "name prefix for bechmarking related artifacts"
 }
+variable organization {
+  description = "name of the organization (eg. harvard, washu)"
+}


### PR DESCRIPTION
this PR contains the terraform code to create an s3 bucket for aqacf. I tested accessing the bucket using my personal aws account and it worked fine. @LiamBindle I think it makes sense for this bucket to be owned by washu, so you will need to terraform apply with the updated code. We will need the account number of the team member we are delivering the data to. Additionally, I have set this up so that all admin users of the given account have read access to the bucket (and can delegate access to other users in the account), but we can coordinate with the AQACF folks for what type of access they need.

Additionally I added the following updates:
- ability to pass in bucket policies to the s3 bucket module
- pattern for conditionally creating a module for a specific environment only (eg. `washu_only` and `harvard_only` local variables)