### PR TITLE
Feature/dashboard: Port over gc testing dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .env
 registry.terraform.io*
 **/modules.json
+benchmarks/dashboard/packages/*

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.formatting.provider": "black"
+}

--- a/benchmarks/dashboard/README.md
+++ b/benchmarks/dashboard/README.md
@@ -1,0 +1,11 @@
+# GC Testing Dashboard
+This directory houses the code for the GC Testing dashboard that tracks simulations and difference plots.
+
+## Creating layers
+To add new python packages to the custom layers:
+
+1. Update the requirements.txt file with the desired package
+2. run `./package_layers.sh`
+
+## Deploy lambda function
+`terraform apply` from the relevant deploy directory

--- a/benchmarks/dashboard/package_layers.sh
+++ b/benchmarks/dashboard/package_layers.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -x
+pkg_dir="packages/python"
+
+echo "Installing python dependencies to ${pkg_dir}"
+mkdir -p ${pkg_dir}
+python3.9 -m pip install -r src/requirements.txt --target ${pkg_dir}

--- a/benchmarks/dashboard/src/geoschem_testing.py
+++ b/benchmarks/dashboard/src/geoschem_testing.py
@@ -1,0 +1,621 @@
+import dataclasses
+import re
+import typing
+import boto3
+import jinja2
+from datetime import date
+
+# This file could be split into seperate model.py, view.py, and controller.py modules.
+
+#== helpers ==
+
+def dynamodb_encode_item(v):
+    if isinstance(v, str):
+        return {"S": v}
+    elif isinstance(v, bool):
+        return {"BOOL": v}
+    elif isinstance(v, list):
+        return {"L": [dynamodb_encode_item(e) for e in v]}
+    elif isinstance(v, dict):
+        return {"M": { kk: dynamodb_encode_item(vv) for kk, vv in v.items()}}
+    else:
+        raise TypeError(f"Invalid type for encoding: {type(v).__name__}")
+
+def dynamodb_encode_dict(d: dict):
+    new_dict = {}
+    for k, v in d.items():
+        new_dict[k] = dynamodb_encode_item(v)
+    return new_dict
+
+
+def dynamodb_decode_item(d: dict):
+    if not isinstance(d, dict):
+        raise TypeError(f"Value of DynamoDB dict is not a nested dict.")
+    if len(d) != 1:
+        raise ValueError(f"Number of key-value pairs in DynamoDB dict is not one.")
+    item = list(d.values())[0]
+    if isinstance(item, list):
+        item = [dynamodb_decode_item(e) for e in item]
+    elif isinstance(item, dict):
+        item = {k: dynamodb_decode_item(v) for k, v in item.items()}
+    return item
+
+
+def dynamodb_decode_dict(d: dict):
+    new_dict = {}
+    for k, v in d.items():
+        new_dict[k] = dynamodb_decode_item(v)
+    return new_dict
+
+
+# == MODEL ==
+
+
+@dataclasses.dataclass
+class PrimaryKeyClassification:
+    classification: str = None
+    api: str = None
+    primary_key: dataclasses.InitVar[str] = None
+    code_url: str = None
+    commit_id: str = None
+
+    def __post_init__(self, primary_key):
+        semver_re = r"(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?"
+        commit_hash_re = r"[0-9a-f]{7}"
+        simulation_re = fr"(gcc|gchp)-((2x25|2x2\.5|4x5|c?24|c?48|c?90|c?180)-)?(1Mon-|1Hr-)?({semver_re}|{commit_hash_re})(\.bd)?"
+        diff_of_diffs_re = fr"diff-of-diffs-1Mon-(gcc|gchp)-(2x25|2x2\.5|4x5|c?24|c?48|c?90|c?180)-(gcc|gchp)-(2x25|2x2\.5|4x5|c?24|c?48|c?90|c?180)-({semver_re}|{commit_hash_re})-({semver_re}|{commit_hash_re})"
+        if re.match(fr"^{simulation_re}$", primary_key):
+            if re.match(r"^gchp", primary_key):
+                self.classification = "GEOS-Chem Simulation"
+                repo = "GCHP"
+            else:
+                self.classification = "GEOS-Chem Simulation"
+                repo="GCClassic"
+            semver_tag = re.search(semver_re, primary_key)
+            if semver_tag:
+                self.commit_id = semver_tag.group(0)
+                self.commit_id = self.commit_id.removesuffix(".bd")  # for old entries
+                self.code_url = f"https://github.com/geoschem/{repo}/tree/{self.commit_id}"
+            commit_hash = re.search(commit_hash_re, primary_key)
+            if commit_hash:
+                self.commit_id = commit_hash.group(0)
+                self.commit_id = self.commit_id.removesuffix(".bd")  # for old entries
+                self.code_url = f"https://github.com/geoschem/{repo}/commit/{self.commit_id}"
+            self.api = "simulation"
+        elif re.match(fr"^diff-{simulation_re}-{simulation_re}$", primary_key):
+            self.classification = "Difference Plots"
+            self.api = "difference"
+        elif re.match(diff_of_diffs_re, primary_key):
+            self.classification = "Difference Plots"
+            self.api = "difference"
+        else:
+            self.classification = "Unknown"
+            self.api = None
+
+
+@dataclasses.dataclass
+class RegistryEntry:
+    primary_key: str = None
+    creation_date: str = None
+    execution_status: str = None
+    execution_site: str = None
+    s3_uri: str = None
+    description: str = None
+    primary_key_classification: PrimaryKeyClassification = None
+    dynamodb_scan_result: dataclasses.InitVar[dict] = None
+
+    def __post_init__(self, dynamodb_scan_result):
+        if dynamodb_scan_result is not None:
+            dynamodb_scan_result = dynamodb_decode_dict(dynamodb_scan_result)
+            self.primary_key = dynamodb_scan_result.get("InstanceID")
+            self.creation_date = dynamodb_scan_result.get("CreationDate")
+            self.execution_status = dynamodb_scan_result.get("ExecStatus")
+            self.execution_site = dynamodb_scan_result.get("Site")
+            self.s3_uri = dynamodb_scan_result.get("S3Uri")
+            self.description = dynamodb_scan_result.get("Description")
+        self.primary_key_classification = PrimaryKeyClassification(primary_key=self.primary_key)
+
+
+@dataclasses.dataclass
+class RegistryEntryStage:
+    name: str = None
+    completed: bool = None
+    log_file: str = None
+    start_time: str = None
+    end_time: str = None
+    artifacts: typing.List[str] = dataclasses.field(default_factory=list)
+    public_artifacts: typing.List[str] = dataclasses.field(default_factory=list)
+    metadata: str = "{}"
+    dynamodb_stage_result: dataclasses.InitVar[dict] = None
+
+    def __post_init__(self, dynamodb_stage_result):
+        if dynamodb_stage_result is not None:
+            dynamodb_stage_result = dynamodb_decode_dict(dynamodb_stage_result)
+            self.name = dynamodb_stage_result.get("Name")
+            self.log_file = dynamodb_stage_result.get("Log")
+            self.completed = dynamodb_stage_result.get("Completed")
+            self.start_time = dynamodb_stage_result.get("StartTime")
+            self.end_time = dynamodb_stage_result.get("EndTime")
+            self.artifacts = dynamodb_stage_result.get("Artifacts")
+            self.public_artifacts = dynamodb_stage_result.get("PublicArtifacts")
+            self.metadata = dynamodb_stage_result.get("Metadata")
+
+
+@dataclasses.dataclass
+class RegistryEntrySimulation(RegistryEntry):
+    setup_run_directory: RegistryEntryStage = None
+    run_simulation_directory: RegistryEntryStage = None
+    dynamodb_query_result: dataclasses.InitVar[dict] = None
+
+    def __post_init__(self, dynamodb_scan_result, dynamodb_query_result):
+        if dynamodb_query_result is not None:
+            super().__post_init__(dynamodb_query_result)
+            stages = dynamodb_query_result["Stages"]["L"]
+            self.setup_run_directory = RegistryEntryStage(dynamodb_stage_result=stages[0].get("M", {}) if len(stages) >= 1 else {})
+            self.run_simulation_directory = RegistryEntryStage(dynamodb_stage_result=stages[1].get("M", {}) if len(stages) >= 2 else {})
+        else:
+            super().__post_init__(dynamodb_scan_result)
+
+
+@dataclasses.dataclass
+class RegistryEntryDiff(RegistryEntry):
+    run_gcpy_stage: RegistryEntryStage = None
+    emissions_totals_link: str = None
+    global_mass_trop_link: str = None
+    global_mass_tropstrat_link: str = None
+    inventory_totals_link: str = None
+    oh_metrics_link: str = None
+    dynamodb_query_result: dataclasses.InitVar[dict] = None
+
+    def __post_init__(self, dynamodb_scan_result, dynamodb_query_result):
+        if dynamodb_query_result is not None:
+            super().__post_init__(dynamodb_query_result)
+            stages = dynamodb_query_result["Stages"]["L"]
+            self.run_gcpy_stage = RegistryEntryStage(dynamodb_stage_result=stages[0].get("M", {}) if len(stages) >= 1 else {})
+        else:
+            super().__post_init__(dynamodb_scan_result)
+
+
+@dataclasses.dataclass
+class NewDifferencePlot:
+    ref: str
+    dev: str
+    execution_site: str
+
+    def get_put_item(self):
+        primary_key = f"diff-{self.ref}-{self.dev}"
+
+        if "-1Hr-" in self.ref:
+            s3_uri_suffix = "1Hr"
+        elif "-1Day-" in self.ref:
+            s3_uri_suffix = "1Day"
+        elif r"-1Mon-" in self.ref:
+            s3_uri_suffix = "1Mon"
+        else:
+            raise RuntimeError("No period regex matched reference key")
+        if self.execution_site == "AWS":
+            s3_uri = "s3://benchmarks-cloud/diff-plots"
+        elif self.execution_site == "WUSTL":
+            s3_uri = "s3://washu-benchmarks-cloud/diff-plots"
+        else:
+            raise RuntimeError("Invalid site.")
+        s3_uri = f"{s3_uri}/{s3_uri_suffix}/{primary_key}"
+
+        item = {
+            "InstanceID": primary_key,
+            "CreationDate": date.today().isoformat(),
+            "ExecStatus": "PENDING",
+            "S3Uri": s3_uri,
+            "Description": f"Benchmark plots for Ref={self.ref} and Dev={self.dev} ({s3_uri_suffix})",
+            "Site": self.execution_site,
+            "Stages": [],
+        }
+        item = dynamodb_encode_dict(item)
+        return item
+
+
+#== VIEW ==
+
+html_page_begin="""<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>GEOS-Chem Testing Dashboard</title>
+    <style>th,td {
+            text-align:left;
+            vertical-align:top;
+            font-family:monospace;
+            padding-left:2em;
+        }
+    </style>
+    <meta charset="UTF-8">
+</head>
+<body>
+"""
+html_page_end="""</body>
+</html>
+"""
+
+dashboard_template="""
+<h2>Registered Simulations</h2>
+<table>
+    <tr><th>Simulation ID</th><th>Date</th><th>Status</th><th>Code Url</th><th>Site</th><th>Description</th></tr>
+{%- for entry in entries -%}
+    {%- if entry.primary_key_classification.classification == 'GEOS-Chem Simulation' -%}
+    <tr>
+        {%- if entry.primary_key_classification.api is not none -%}
+        <td><a href="{{ entry.primary_key_classification.api }}?primary_key={{ entry.primary_key }}">{{ entry.primary_key }}</a></td>
+        {%- else -%}
+        <td>{{ entry.primary_key }}</td>
+        {%- endif -%}
+        <td>{{ entry.creation_date }}</td>
+        <td>{{ entry.execution_status }}</td>
+        <td><a href="{{ entry.primary_key_classification.code_url }}">{{ entry.primary_key_classification.commit_id }}</a></td>
+        <td>{{ entry.execution_site }}</td>
+        <td>{{ entry.description }}</td>
+    </tr>
+    {%- endif -%}
+{%- endfor -%}
+</table>
+
+<hr>
+<h2>Difference Plots</h2>
+<table>
+    <tr><th>ID</th><th>Date</th><th>Status</th><th>Site</th><th>Description</th></tr>
+{%- for entry in entries -%}
+    {%- if entry.primary_key_classification.classification == 'Difference Plots' -%}
+    <tr>
+        {%- if entry.primary_key_classification.api is not none -%}
+        <td><a href="{{ entry.primary_key_classification.api }}?primary_key={{ entry.primary_key }}">{{ entry.primary_key }}</a></td>
+        {%- else -%}
+        <td>{{ entry.primary_key }}</td>
+        {%- endif -%}
+        <td>{{ entry.creation_date }}</td>
+        <td>{{ entry.execution_status }}</td>
+        <td>{{ entry.execution_site }}</td>
+        <td>{{ entry.description }}</td>
+    </tr>
+    {%- endif -%}
+{%- endfor -%}
+</table>
+
+<hr>
+<h2>Unclassified Entries</h2>
+<table>
+    <tr><th>ID</th><th>Date</th><th>Status</th><th>Site</th><th>Description</th></tr>
+{%- for entry in entries -%}
+    {%- if entry.primary_key_classification.classification == 'Unknown' -%}
+    <tr>
+        <td>{{ entry.primary_key }}</td>
+        <td>{{ entry.creation_date }}</td>
+        <td>{{ entry.execution_status }}</td>
+        <td>{{ entry.execution_site }}</td>
+        <td>{{ entry.description }}</td>
+    </tr>
+    {%- endif -%}
+{%- endfor -%}
+</table>
+"""
+
+simulation_template="""
+<table>
+    <tr><th>Name</th><th>Value</th></tr>
+    <tr>
+        <td>Primary Key</td>
+        <td>{{ entry.primary_key }}</td>
+    </tr>
+    <tr>
+        <td>Creation Date</td>
+        <td>{{ entry.creation_date }}</td>
+    </tr>
+    <tr>
+        <td>Execution Status</td>
+        <td>{{ entry.execution_status }}</td>
+    </tr>
+    <tr>
+        <td>Execution Site</td>
+        <td>{{ entry.execution_site }}</td>
+    </tr>
+    <tr>
+        <td>S3 Uri Site</td>
+        <td>{{ entry.s3_uri }}</td>
+    </tr>
+    <tr>
+        <td>Description</td>
+        <td>{{ entry.description }}</td>
+    </tr>
+    <tr>
+        <td>Setup Run Directory</td>
+        {%- if entry.setup_run_directory is not none -%}
+        <td>
+            <table>
+                <tr>
+                    <td>Completed</td>
+                    <td>{{ entry.setup_run_directory.completed }}</td>
+                </tr>
+                <tr>
+                    <td>Log File</td>
+                    <td><a href="{{ entry.setup_run_directory.log_file }}">{{ entry.setup_run_directory.log_file }}</a></td>
+                </tr>
+                <tr>
+                    <td>Start Time</td>
+                    <td>{{ entry.setup_run_directory.start_time }}</td>
+                </tr>
+                <tr>
+                    <td>End Time</td>
+                    <td>{{ entry.setup_run_directory.end_time }}</td>
+                </tr>
+                <tr>
+                    <td>Public Artifacts</td>
+                    <td>
+                    {%- for artifact in entry.setup_run_directory.public_artifacts -%}
+                        <a href="{{ artifact }}">{{ artifact }}</a><br>
+                    {%- endfor -%}
+                    </td>
+                </tr>
+                <tr>
+                    <td>Stage Artifacts</td>
+                    <td>
+                    {%- for artifact in entry.setup_run_directory.artifacts -%}
+                        {{ artifact }}<br>
+                    {%- endfor -%}
+                    </td>
+                </tr>
+                <tr>
+                    <td>Metadata</td>
+                    <td>{{ entry.setup_run_directory.metadata }}</td>
+                </tr>
+            </table>
+        </td>
+        {%- else -%}
+        <td>n/a</td>
+        {%- endif -%}
+        
+        <tr>
+        <td>Run Simulation</td>
+        {%- if entry.run_simulation_directory is not none -%}
+        <td>
+            <table>
+                <tr>
+                    <td>Completed</td>
+                    <td>{{ entry.run_simulation_directory.completed }}</td>
+                </tr>
+                <tr>
+                    <td>Log File</td>
+                    <td><a href="{{ entry.run_simulation_directory.log_file }}">{{ entry.run_simulation_directory.log_file }}</a></td>
+                </tr>
+                <tr>
+                    <td>Start Time</td>
+                    <td>{{ entry.run_simulation_directory.start_time }}</td>
+                </tr>
+                <tr>
+                    <td>End Time</td>
+                    <td>{{ entry.run_simulation_directory.end_time }}</td>
+                </tr>
+                <tr>
+                    <td>Public Artifacts</td>
+                    <td>
+                    {%- for artifact in entry.run_simulation_directory.public_artifacts -%}
+                        <a href="{{ artifact }}">{{ artifact }}</a><br>
+                    {%- endfor -%}
+                    </td>
+                </tr>
+                <tr>
+                    <td>Stage Artifacts</td>
+                    <td>
+                    {%- for artifact in entry.run_simulation_directory.artifacts -%}
+                        {{ artifact }}<br>
+                    {%- endfor -%}
+                    </td>
+                </tr>
+                <tr>
+                    <td>Metadata</td>
+                    <td>{{ entry.run_simulation_directory.metadata }}</td>
+                </tr>
+            </table>
+        </td>
+        {%- else -%}
+        <td>n/a</td>
+        {%- endif -%}
+    </tr>
+</table>
+"""
+
+difference_template = """
+<table>
+    <tr><th>Name</th><th>Value</th></tr>
+    <tr>
+        <td>Primary Key</td>
+        <td>{{ entry.primary_key }}</td>
+    </tr>
+    <tr>
+        <td>Creation Date</td>
+        <td>{{ entry.creation_date }}</td>
+    </tr>
+    <tr>
+        <td>Execution Status</td>
+        <td>{{ entry.execution_status }}</td>
+    </tr>
+    <tr>
+        <td>Execution Site</td>
+        <td>{{ entry.execution_site }}</td>
+    </tr>
+    <tr>
+        <td>S3 Uri Site</td>
+        <td>{{ entry.s3_uri }}</td>
+    </tr>
+    <tr>
+        <td>Description</td>
+        <td>{{ entry.description }}</td>
+    </tr>
+    <tr>
+        <td>GCPy Output</td>
+        {%- if entry.run_gcpy_stage is not none -%}
+        <td>
+            <table>
+                <tr>
+                    <td>Completed</td>
+                    <td>{{ entry.run_gcpy_stage.completed }}</td>
+                </tr>
+                <tr>
+                    <td>Log File</td>
+                    <td><a href="{{ entry.run_gcpy_stage.log_file }}">{{ entry.run_gcpy_stage.log_file }}</a></td>
+                </tr>
+                <tr>
+                    <td>Start Time</td>
+                    <td>{{ entry.run_gcpy_stage.start_time }}</td>
+                </tr>
+                <tr>
+                    <td>End Time</td>
+                    <td>{{ entry.run_gcpy_stage.end_time }}</td>
+                </tr>
+                <tr>
+                    <td>Public Artifacts</td>
+                    <td>
+                    {%- for artifact in entry.run_gcpy_stage.public_artifacts -%}
+                        <a href="{{ artifact }}">{{ artifact }}</a><br>
+                    {%- endfor -%}
+                    </td>
+                </tr>
+                <tr>
+                    <td>Stage Artifacts</td>
+                    <td>
+                    {%- for artifact in entry.run_gcpy_stage.artifacts -%}
+                        {{ artifact }}<br>
+                    {%- endfor -%}
+                    </td>
+                </tr>
+                <tr>
+                    <td>Metadata</td>
+                    <td>{{ entry.run_gcpy_stage.metadata }}</td>
+                </tr>
+            </table>
+        </td>
+        {%- else -%}
+        <td>n/a</td>
+        {%- endif -%}
+    </tr>
+</table>
+"""
+
+
+def fill_template(template_str, **kwargs):
+    env = jinja2.Environment()
+    html_page = html_page_begin + env.from_string(template_str).render(**kwargs) + html_page_end
+    html_page = html_page.replace("SUCCESSFUL", '<span style="color:green">✅ SUCCESSFUL</span>')
+    html_page = html_page.replace("IN_PROGRESS", '<span style="color:orange">⌛ IN_PROGRESS</span>')
+    html_page = html_page.replace("FAILED", '<span style="color:red">❌ FAILED</span>')
+    return html_page
+
+
+def get_dashboard_page(sorted_entries):
+    return fill_template(dashboard_template, entries=sorted_entries)
+
+
+def get_simulation_page(entry):
+    return fill_template(simulation_template, entry=entry)
+
+
+def get_difference_page(entry):
+    return fill_template(difference_template, entry=entry)
+
+
+#== CONTROLLER ==
+TABLE_NAME="geoschem_testing"
+
+def get_dynamodb_client():
+    dynamodb_client = boto3.client('dynamodb')
+    return dynamodb_client
+
+def parse_scan_response(response):
+    entries = []
+    for item in response:
+        entries.append(RegistryEntry(dynamodb_scan_result=item))
+    return entries
+
+
+def scan_registry():
+    client = get_dynamodb_client()
+    response = client.scan(
+        TableName=TABLE_NAME,
+        ProjectionExpression='InstanceID,CreationDate,ExecStatus,Site,Description',
+    )
+    return parse_scan_response(response['Items'])
+
+
+def parse_query_response_astype(query_results, astype):
+    entries = []
+    for item in query_results:
+        entries.append(astype(dynamodb_query_result=item))
+    return entries
+
+
+def query_registry(items, astype):
+    client = get_dynamodb_client()
+
+    if isinstance(items, str):
+        request_keys = [{"InstanceID": {"S": items}}]
+    else:
+        request_keys = [{"InstanceID": {"S": item.primary_key}} for item in items]
+    response = client.batch_get_item(
+        RequestItems={TABLE_NAME: {'Keys': request_keys}}
+    )
+
+    if astype is dict:
+        return [dynamodb_decode_dict(response) for response in response["Responses"][TABLE_NAME]]
+    else:
+        return parse_query_response_astype(response["Responses"][TABLE_NAME], astype)
+
+
+def dashboard(event, context):
+    print(event)
+    if event['rawPath'] == "/difference":
+        difference(event, context)
+    elif event['rawPath'] == "/simulation":
+        simulation(event, context)
+    else:
+        entries = scan_registry()
+        entries.sort(key=lambda entry: entry.creation_date, reverse=True)
+        html_page = get_dashboard_page(entries)
+        return {
+            "statusCode": 200,
+            "headers": {
+                'Content-Type': 'text/html',
+            },
+            "body": html_page,
+        }
+
+
+def simulation(event, context):
+    primary_key = event['queryStringParameters']['primary_key']
+    entries = query_registry(primary_key, RegistryEntrySimulation)
+    html_page = get_simulation_page(entry=entries[0])
+    return {
+        "statusCode": 200,
+        "headers": {
+            'Content-Type': 'text/html',
+        },
+        "body": html_page,
+    }
+
+
+def difference(event, context):
+    primary_key = event['queryStringParameters']['primary_key']
+    entries = query_registry(primary_key, RegistryEntryDiff)
+    html_page = get_difference_page(entry=entries[0])
+    return {
+        "statusCode": 200,
+        "headers": {
+            'Content-Type': 'text/html',
+        },
+        "body": html_page,
+    }
+
+def handler(event, context):
+
+    if event['rawPath'] == "/difference":
+        output = difference(event, context)
+    elif event['rawPath'] == "/simulation":
+        output = simulation(event, context)
+    else:
+        output = dashboard(event, context)
+    return output

--- a/benchmarks/dashboard/src/geoschem_testing_test.py
+++ b/benchmarks/dashboard/src/geoschem_testing_test.py
@@ -1,0 +1,196 @@
+#
+# Run `python -m pytest` to run these tests.
+#
+
+import json
+from .geoschem_testing import *
+
+
+def test_encoding_decoding_dynamodb_dict():
+    test_dict_decoded = {
+        "string1": "foobar",
+        "map1": { "string2": "foo", "bool1": False },
+        "list1": ["string3", "string4"],
+    }
+
+    test_dict_encoded = {
+        "string1": {"S": "foobar"},
+        "map1": {
+            "M": {
+                "string2": {"S": "foo"},
+                "bool1": {"BOOL": False}
+            },
+        },
+        "list1": {
+            "L": [
+                {"S": "string3"},
+                {"S": "string4"}
+            ]
+        }
+    }
+
+    decoding_answer = dynamodb_decode_dict(test_dict_encoded)
+    assert decoding_answer == test_dict_decoded
+
+    encoding_answer = dynamodb_encode_dict(test_dict_decoded)
+    assert encoding_answer == test_dict_encoded
+
+
+def test_primary_key_classification():
+    assert PrimaryKeyClassification(primary_key="gchp-1Mon-13.4.0-rc.3.bd").classification == "GEOS-Chem Simulation"
+    assert PrimaryKeyClassification(primary_key="gchp-1Mon-13.4.0-rc.3").classification == "GEOS-Chem Simulation"
+    assert PrimaryKeyClassification(primary_key="gchp-c24-1Mon-13.4.0-rc.3").classification == "GEOS-Chem Simulation"
+    assert PrimaryKeyClassification(primary_key="gcc-1Hr-483b659.bd").classification == "GEOS-Chem Simulation"
+    assert PrimaryKeyClassification(primary_key="gcc-1Hr-483b659").classification == "GEOS-Chem Simulation"
+    assert PrimaryKeyClassification(primary_key="gcc-4x5-1Hr-483b659").classification == "GEOS-Chem Simulation"
+    assert PrimaryKeyClassification(primary_key="diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27").classification == "Difference Plots"
+
+
+def test_parsing_scan():
+    with open("test_data/scan_results.json") as f:
+        response = json.load(f)['Items']
+    entries = parse_scan_response(response)
+
+    an_entry_that_should_exist = RegistryEntry(
+        primary_key="gcc-1Hr-f9a901a.bd", creation_date="2022-03-24", execution_status="FAILED",
+        execution_site="AWS", description="1Hr gcc benchmark simulation using 'f9a901a'",
+        s3_uri="s3://benchmarks-cloud/benchmarks/1Hr/gcc/gcc-1Hr-f9a901a.bd",
+
+    )
+    assert any([entry == an_entry_that_should_exist for entry in entries])
+
+
+def test_parsing_query():
+    with open("test_data/query_result.json") as f:
+        response = [json.load(f)['Item']]
+    entries = parse_query_response_astype(response, RegistryEntrySimulation)
+
+    an_entry_that_should_exist = RegistryEntrySimulation(
+        primary_key="gchp-1Mon-13.4.0-rc.3.bd", creation_date="2022-03-28", execution_status="SUCCESSFUL",
+        execution_site="AWS", description="1Mon gchp benchmark simulation using '13.4.0-rc.3'",
+        s3_uri="s3://benchmarks-cloud/benchmarks/1Mon/gchp/gchp-1Mon-13.4.0-rc.3.bd",
+    )
+    an_entry_that_should_exist.setup_run_directory = RegistryEntryStage(
+        name="SetupRunDirectory", completed=True, log_file="http://s3.amazonaws.com/benchmarks-cloud/benchmarks/1Mon/gchp/gchp-1Mon-13.4.0-rc.3.bd/SetupRunDirectory.txt",
+        start_time="2022-03-28T17:45:04+0000", end_time="2022-03-28T18:00:15+0000", metadata="{}",
+        artifacts=["s3://benchmarks-cloud/benchmarks/1Mon/gchp/gchp-1Mon-13.4.0-rc.3.bd/SetupRunDirectory_RunDirectory.tar.gz"],
+        public_artifacts=[],
+    )
+    an_entry_that_should_exist.run_simulation_directory = RegistryEntryStage(
+        name="RunGCHP", completed=True,
+        log_file="http://s3.amazonaws.com/benchmarks-cloud/benchmarks/1Mon/gchp/gchp-1Mon-13.4.0-rc.3.bd/RunGCHP.txt",
+        start_time="2022-03-28T19:26:04+0000", end_time="2022-03-29T01:45:15+0000", metadata="{}",
+        artifacts=[
+            "s3://benchmarks-cloud/benchmarks/1Mon/gchp/gchp-1Mon-13.4.0-rc.3.bd/RunGCHP_OutputDir.tar.gz"],
+        public_artifacts=[],
+    )
+    assert entries[0] == an_entry_that_should_exist
+
+
+def test_parsing_diff_query():
+    with open("test_data/diff_query_result.json") as f:
+        response = [json.load(f)['Item']]
+    entries = parse_query_response_astype(response, RegistryEntryDiff)
+
+    an_entry_that_should_exist = RegistryEntryDiff(
+        primary_key="diff-gcc-1Hr-3f70328.bd-gcc-1Hr-3f70328.bd", creation_date="2022-04-04", execution_status="SUCCESSFUL",
+        execution_site="AWS", description="1Hr Benchmark plot creation (ref: 'gcc-1Hr-3f70328.bd'; dev:'gcc-1Hr-3f70328.bd')",
+        s3_uri="s3://benchmarks-cloud/diff-plots/1Hr/diff-gcc-1Hr-3f70328.bd-gcc-1Hr-3f70328.bd",
+    )
+    an_entry_that_should_exist.run_gcpy_stage = RegistryEntryStage(
+        name="CreateBenchmarkPlots", completed=True, log_file="http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Hr/diff-gcc-1Hr-3f70328.bd-gcc-1Hr-3f70328.bd/CreateBenchmarkPlots.txt",
+        start_time="2022-04-04T17:22:44+0000", end_time="2022-04-04T17:23:32+0000", metadata="{}",
+        artifacts=[],
+        public_artifacts=[
+            "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Hr/diff-gcc-1Hr-3f70328.bd-gcc-1Hr-3f70328.bd/BenchmarkResults/Tables/Emission_totals.txt",
+            "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Hr/diff-gcc-1Hr-3f70328.bd-gcc-1Hr-3f70328.bd/BenchmarkResults/Tables/GlobalMass_Trop.txt",
+            "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Hr/diff-gcc-1Hr-3f70328.bd-gcc-1Hr-3f70328.bd/BenchmarkResults/Tables/GlobalMass_TropStrat.txt",
+            "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Hr/diff-gcc-1Hr-3f70328.bd-gcc-1Hr-3f70328.bd/BenchmarkResults/Tables/Inventory_totals.txt",
+            "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Hr/diff-gcc-1Hr-3f70328.bd-gcc-1Hr-3f70328.bd/BenchmarkResults/Tables/OH_metrics.txt",
+        ],
+    )
+
+    assert entries[0] == an_entry_that_should_exist
+
+def test_parsing_diff_of_diffs_query():
+    with open("test_data/diff_of_diffs_query_result.json") as f:
+        response = [json.load(f)['Item']]
+    entries = parse_query_response_astype(response, RegistryEntryDiff)
+
+    an_entry_that_should_exist = RegistryEntryDiff(
+        primary_key="diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27", creation_date="2022-04-13",
+        execution_status="SUCCESSFUL",
+        execution_site="AWS",
+        description="1Mon Benchmark plot diff of diffs (ref: 'gchp-c24-1Mon-13.4.0-alpha.26'; dev: 'gchp-c24-1Mon-13.4.0-alpha.27'; dev: 'gcc-c24-1Mon-13.4.0-alpha.27'; ref: 'gcc-c24-1Mon-13.4.0-alpha.26)",
+        s3_uri="s3://benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27",
+    )
+    an_entry_that_should_exist.run_gcpy_stage = RegistryEntryStage(
+        name="CreateBenchmarkPlots", completed=True,
+        log_file="http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/CreateBenchmarkPlots.txt",
+        start_time="2022-04-13T20:44:26+0000", end_time="2022-04-13T20:53:47+0000", metadata="{}",
+        artifacts=[],
+        public_artifacts=[
+            "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/lumped_species.yml",
+            "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/benchmark_categories.yml",
+            "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/Aerosols/Aerosols_Surface.pdf",
+            "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/Aerosols/Aerosols_500hPa.pdf",
+            "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/Aerosols/Aerosols_FullColumn_ZonalMean.pdf",
+            "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/Aerosols/Aerosols_Strat_ZonalMean.pdf",
+            "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/Bromine/Bromine_Surface.pdf",
+            "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/Bromine/Bromine_500hPa.pdf",
+            "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/Bromine/Bromine_FullColumn_ZonalMean.pdf",
+            "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/Bromine/Bromine_Strat_ZonalMean.pdf",
+            "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/Chlorine/Chlorine_Surface.pdf",
+            "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/Chlorine/Chlorine_500hPa.pdf",
+            "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/Chlorine/Chlorine_FullColumn_ZonalMean.pdf",
+            "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/Chlorine/Chlorine_Strat_ZonalMean.pdf",
+            "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/Iodine/Iodine_Surface.pdf",
+            "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/Iodine/Iodine_500hPa.pdf",
+            "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/Iodine/Iodine_FullColumn_ZonalMean.pdf",
+            "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/Iodine/Iodine_Strat_ZonalMean.pdf",
+            "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/Nitrogen/Nitrogen_Surface.pdf",
+            "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/Nitrogen/Nitrogen_500hPa.pdf",
+            "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/Nitrogen/Nitrogen_FullColumn_ZonalMean.pdf",
+            "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/Nitrogen/Nitrogen_Strat_ZonalMean.pdf",
+            "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/Oxidants/Oxidants_Surface.pdf",
+            "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/Oxidants/Oxidants_500hPa.pdf",
+            "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/Oxidants/Oxidants_FullColumn_ZonalMean.pdf",
+            "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/Oxidants/Oxidants_Strat_ZonalMean.pdf",
+            "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/Primary_Organics/Primary_Organics_Surface.pdf",
+            "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/Primary_Organics/Primary_Organics_500hPa.pdf",
+            "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/Primary_Organics/Primary_Organics_FullColumn_ZonalMean.pdf",
+            "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/Primary_Organics/Primary_Organics_Strat_ZonalMean.pdf",
+            "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/ROy/ROy_Surface.pdf",
+            "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/ROy/ROy_500hPa.pdf",
+            "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/ROy/ROy_FullColumn_ZonalMean.pdf",
+            "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/ROy/ROy_Strat_ZonalMean.pdf",
+            "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/Secondary_Organic_Aerosols/Secondary_Organic_Aerosols_Surface.pdf",
+            "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/Secondary_Organic_Aerosols/Secondary_Organic_Aerosols_500hPa.pdf",
+            "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/Secondary_Organic_Aerosols/Secondary_Organic_Aerosols_FullColumn_ZonalMean.pdf",
+            "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/Secondary_Organic_Aerosols/Secondary_Organic_Aerosols_Strat_ZonalMean.pdf",
+            "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/Secondary_Organics/Secondary_Organics_Surface.pdf",
+            "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/Secondary_Organics/Secondary_Organics_500hPa.pdf",
+            "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/Secondary_Organics/Secondary_Organics_FullColumn_ZonalMean.pdf",
+            "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/Secondary_Organics/Secondary_Organics_Strat_ZonalMean.pdf",
+            "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/Sulfur/Sulfur_Surface.pdf",
+            "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/Sulfur/Sulfur_500hPa.pdf",
+            "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/Sulfur/Sulfur_FullColumn_ZonalMean.pdf",
+            "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/Sulfur/Sulfur_Strat_ZonalMean.pdf",
+        ],
+    )
+
+    assert entries[0] == an_entry_that_should_exist
+
+
+def test_diff_plot_get_put_item():
+    new_request = NewDifferencePlot("1234-1Hr-1234", "abcd-1Hr-abcd", "AWS")
+    answer = {
+        "InstanceID": {"S": "diff-1234-1Hr-1234-abcd-1Hr-abcd"},
+        "CreationDate": {"S": date.today().isoformat()},
+        "ExecStatus": {"S": "PENDING"},
+        "S3Uri": {"S": "s3://benchmarks-cloud/diff-plots/1Hr/diff-1234-1Hr-1234-abcd-1Hr-abcd"},
+        "Description": {"S": "Benchmark plots for Ref=1234-1Hr-1234 and Dev=abcd-1Hr-abcd (1Hr)"},
+        "Site": {"S": "AWS"},
+        "Stages": {"L": []}
+    }
+    assert new_request.get_put_item() == answer

--- a/benchmarks/dashboard/src/requirements.txt
+++ b/benchmarks/dashboard/src/requirements.txt
@@ -1,0 +1,3 @@
+requests
+boto3
+jinja2

--- a/benchmarks/dashboard/src/test_data/diff_of_diffs_query_result.json
+++ b/benchmarks/dashboard/src/test_data/diff_of_diffs_query_result.json
@@ -1,0 +1,193 @@
+{
+    "Item": {
+        "CreationDate": {
+            "S": "2022-04-13"
+        },
+        "ExecStatus": {
+            "S": "SUCCESSFUL"
+        },
+        "S3Uri": {
+            "S": "s3://benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27"
+        },
+        "Description": {
+            "S": "1Mon Benchmark plot diff of diffs (ref: 'gchp-c24-1Mon-13.4.0-alpha.26'; dev: 'gchp-c24-1Mon-13.4.0-alpha.27'; dev: 'gcc-c24-1Mon-13.4.0-alpha.27'; ref: 'gcc-c24-1Mon-13.4.0-alpha.26)"
+        },
+        "InstanceID": {
+            "S": "diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27"
+        },
+        "Site": {
+            "S": "AWS"
+        },
+        "Stages": {
+            "L": [
+                {
+                    "M": {
+                        "Artifacts": {
+                            "L": []
+                        },
+                        "EndTime": {
+                            "S": "2022-04-13T20:53:47+0000"
+                        },
+                        "Log": {
+                            "S": "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/CreateBenchmarkPlots.txt"
+                        },
+                        "PublicArtifacts": {
+                            "L": [
+                                {
+                                    "S": "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/lumped_species.yml"
+                                },
+                                {
+                                    "S": "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/benchmark_categories.yml"
+                                },
+                                {
+                                    "S": "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/Aerosols/Aerosols_Surface.pdf"
+                                },
+                                {
+                                    "S": "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/Aerosols/Aerosols_500hPa.pdf"
+                                },
+                                {
+                                    "S": "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/Aerosols/Aerosols_FullColumn_ZonalMean.pdf"
+                                },
+                                {
+                                    "S": "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/Aerosols/Aerosols_Strat_ZonalMean.pdf"
+                                },
+                                {
+                                    "S": "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/Bromine/Bromine_Surface.pdf"
+                                },
+                                {
+                                    "S": "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/Bromine/Bromine_500hPa.pdf"
+                                },
+                                {
+                                    "S": "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/Bromine/Bromine_FullColumn_ZonalMean.pdf"
+                                },
+                                {
+                                    "S": "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/Bromine/Bromine_Strat_ZonalMean.pdf"
+                                },
+                                {
+                                    "S": "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/Chlorine/Chlorine_Surface.pdf"
+                                },
+                                {
+                                    "S": "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/Chlorine/Chlorine_500hPa.pdf"
+                                },
+                                {
+                                    "S": "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/Chlorine/Chlorine_FullColumn_ZonalMean.pdf"
+                                },
+                                {
+                                    "S": "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/Chlorine/Chlorine_Strat_ZonalMean.pdf"
+                                },
+                                {
+                                    "S": "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/Iodine/Iodine_Surface.pdf"
+                                },
+                                {
+                                    "S": "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/Iodine/Iodine_500hPa.pdf"
+                                },
+                                {
+                                    "S": "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/Iodine/Iodine_FullColumn_ZonalMean.pdf"
+                                },
+                                {
+                                    "S": "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/Iodine/Iodine_Strat_ZonalMean.pdf"
+                                },
+                                {
+                                    "S": "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/Nitrogen/Nitrogen_Surface.pdf"
+                                },
+                                {
+                                    "S": "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/Nitrogen/Nitrogen_500hPa.pdf"
+                                },
+                                {
+                                    "S": "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/Nitrogen/Nitrogen_FullColumn_ZonalMean.pdf"
+                                },
+                                {
+                                    "S": "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/Nitrogen/Nitrogen_Strat_ZonalMean.pdf"
+                                },
+                                {
+                                    "S": "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/Oxidants/Oxidants_Surface.pdf"
+                                },
+                                {
+                                    "S": "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/Oxidants/Oxidants_500hPa.pdf"
+                                },
+                                {
+                                    "S": "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/Oxidants/Oxidants_FullColumn_ZonalMean.pdf"
+                                },
+                                {
+                                    "S": "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/Oxidants/Oxidants_Strat_ZonalMean.pdf"
+                                },
+                                {
+                                    "S": "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/Primary_Organics/Primary_Organics_Surface.pdf"
+                                },
+                                {
+                                    "S": "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/Primary_Organics/Primary_Organics_500hPa.pdf"
+                                },
+                                {
+                                    "S": "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/Primary_Organics/Primary_Organics_FullColumn_ZonalMean.pdf"
+                                },
+                                {
+                                    "S": "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/Primary_Organics/Primary_Organics_Strat_ZonalMean.pdf"
+                                },
+                                {
+                                    "S": "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/ROy/ROy_Surface.pdf"
+                                },
+                                {
+                                    "S": "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/ROy/ROy_500hPa.pdf"
+                                },
+                                {
+                                    "S": "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/ROy/ROy_FullColumn_ZonalMean.pdf"
+                                },
+                                {
+                                    "S": "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/ROy/ROy_Strat_ZonalMean.pdf"
+                                },
+                                {
+                                    "S": "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/Secondary_Organic_Aerosols/Secondary_Organic_Aerosols_Surface.pdf"
+                                },
+                                {
+                                    "S": "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/Secondary_Organic_Aerosols/Secondary_Organic_Aerosols_500hPa.pdf"
+                                },
+                                {
+                                    "S": "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/Secondary_Organic_Aerosols/Secondary_Organic_Aerosols_FullColumn_ZonalMean.pdf"
+                                },
+                                {
+                                    "S": "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/Secondary_Organic_Aerosols/Secondary_Organic_Aerosols_Strat_ZonalMean.pdf"
+                                },
+                                {
+                                    "S": "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/Secondary_Organics/Secondary_Organics_Surface.pdf"
+                                },
+                                {
+                                    "S": "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/Secondary_Organics/Secondary_Organics_500hPa.pdf"
+                                },
+                                {
+                                    "S": "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/Secondary_Organics/Secondary_Organics_FullColumn_ZonalMean.pdf"
+                                },
+                                {
+                                    "S": "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/Secondary_Organics/Secondary_Organics_Strat_ZonalMean.pdf"
+                                },
+                                {
+                                    "S": "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/Sulfur/Sulfur_Surface.pdf"
+                                },
+                                {
+                                    "S": "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/Sulfur/Sulfur_500hPa.pdf"
+                                },
+                                {
+                                    "S": "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/Sulfur/Sulfur_FullColumn_ZonalMean.pdf"
+                                },
+                                {
+                                    "S": "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Mon/diff-of-diffs-1Mon-gchp-c24-gcc-c24-13.4.0-alpha.26-13.4.0-alpha.27/BenchmarkResults/GCHP_GCC_diff_of_diffs/Sulfur/Sulfur_Strat_ZonalMean.pdf"
+                                }
+                            ]
+                        },
+                        "Completed": {
+                            "BOOL": true
+                        },
+                        "StartTime": {
+                            "S": "2022-04-13T20:44:26+0000"
+                        },
+                        "Metadata": {
+                            "S": "{}"
+                        },
+                        "Name": {
+                            "S": "CreateBenchmarkPlots"
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/benchmarks/dashboard/src/test_data/diff_query_result.json
+++ b/benchmarks/dashboard/src/test_data/diff_query_result.json
@@ -1,0 +1,70 @@
+{
+    "Item": {
+        "CreationDate": {
+            "S": "2022-04-04"
+        },
+        "ExecStatus": {
+            "S": "SUCCESSFUL"
+        },
+        "S3Uri": {
+            "S": "s3://benchmarks-cloud/diff-plots/1Hr/diff-gcc-1Hr-3f70328.bd-gcc-1Hr-3f70328.bd"
+        },
+        "Description": {
+            "S": "1Hr Benchmark plot creation (ref: 'gcc-1Hr-3f70328.bd'; dev:'gcc-1Hr-3f70328.bd')"
+        },
+        "InstanceID": {
+            "S": "diff-gcc-1Hr-3f70328.bd-gcc-1Hr-3f70328.bd"
+        },
+        "Site": {
+            "S": "AWS"
+        },
+        "Stages": {
+            "L": [
+                {
+                    "M": {
+                        "Artifacts": {
+                            "L": []
+                        },
+                        "EndTime": {
+                            "S": "2022-04-04T17:23:32+0000"
+                        },
+                        "Log": {
+                            "S": "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Hr/diff-gcc-1Hr-3f70328.bd-gcc-1Hr-3f70328.bd/CreateBenchmarkPlots.txt"
+                        },
+                        "PublicArtifacts": {
+                            "L": [
+                                {
+                                    "S": "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Hr/diff-gcc-1Hr-3f70328.bd-gcc-1Hr-3f70328.bd/BenchmarkResults/Tables/Emission_totals.txt"
+                                },
+                                {
+                                    "S": "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Hr/diff-gcc-1Hr-3f70328.bd-gcc-1Hr-3f70328.bd/BenchmarkResults/Tables/GlobalMass_Trop.txt"
+                                },
+                                {
+                                    "S": "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Hr/diff-gcc-1Hr-3f70328.bd-gcc-1Hr-3f70328.bd/BenchmarkResults/Tables/GlobalMass_TropStrat.txt"
+                                },
+                                {
+                                    "S": "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Hr/diff-gcc-1Hr-3f70328.bd-gcc-1Hr-3f70328.bd/BenchmarkResults/Tables/Inventory_totals.txt"
+                                },
+                                {
+                                    "S": "http://s3.amazonaws.com/benchmarks-cloud/diff-plots/1Hr/diff-gcc-1Hr-3f70328.bd-gcc-1Hr-3f70328.bd/BenchmarkResults/Tables/OH_metrics.txt"
+                                }
+                            ]
+                        },
+                        "Completed": {
+                            "BOOL": true
+                        },
+                        "StartTime": {
+                            "S": "2022-04-04T17:22:44+0000"
+                        },
+                        "Metadata": {
+                            "S": "{}"
+                        },
+                        "Name": {
+                            "S": "CreateBenchmarkPlots"
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/benchmarks/dashboard/src/test_data/query_result.json
+++ b/benchmarks/dashboard/src/test_data/query_result.json
@@ -1,0 +1,90 @@
+{
+    "Item": {
+        "CreationDate": {
+            "S": "2022-03-28"
+        },
+        "ExecStatus": {
+            "S": "SUCCESSFUL"
+        },
+        "S3Uri": {
+            "S": "s3://benchmarks-cloud/benchmarks/1Mon/gchp/gchp-1Mon-13.4.0-rc.3.bd"
+        },
+        "Description": {
+            "S": "1Mon gchp benchmark simulation using '13.4.0-rc.3'"
+        },
+        "InstanceID": {
+            "S": "gchp-1Mon-13.4.0-rc.3.bd"
+        },
+        "Site": {
+            "S": "AWS"
+        },
+        "Stages": {
+            "L": [
+                {
+                    "M": {
+                        "Artifacts": {
+                            "L": [
+                                {
+                                    "S": "s3://benchmarks-cloud/benchmarks/1Mon/gchp/gchp-1Mon-13.4.0-rc.3.bd/SetupRunDirectory_RunDirectory.tar.gz"
+                                }
+                            ]
+                        },
+                        "EndTime": {
+                            "S": "2022-03-28T18:00:15+0000"
+                        },
+                        "Log": {
+                            "S": "http://s3.amazonaws.com/benchmarks-cloud/benchmarks/1Mon/gchp/gchp-1Mon-13.4.0-rc.3.bd/SetupRunDirectory.txt"
+                        },
+                        "PublicArtifacts": {
+                            "L": []
+                        },
+                        "Completed": {
+                            "BOOL": true
+                        },
+                        "StartTime": {
+                            "S": "2022-03-28T17:45:04+0000"
+                        },
+                        "Metadata": {
+                            "S": "{}"
+                        },
+                        "Name": {
+                            "S": "SetupRunDirectory"
+                        }
+                    }
+                },
+                {
+                    "M": {
+                        "Artifacts": {
+                            "L": [
+                                {
+                                    "S": "s3://benchmarks-cloud/benchmarks/1Mon/gchp/gchp-1Mon-13.4.0-rc.3.bd/RunGCHP_OutputDir.tar.gz"
+                                }
+                            ]
+                        },
+                        "EndTime": {
+                            "S": "2022-03-29T01:45:15+0000"
+                        },
+                        "Log": {
+                            "S": "http://s3.amazonaws.com/benchmarks-cloud/benchmarks/1Mon/gchp/gchp-1Mon-13.4.0-rc.3.bd/RunGCHP.txt"
+                        },
+                        "PublicArtifacts": {
+                            "L": []
+                        },
+                        "Completed": {
+                            "BOOL": true
+                        },
+                        "StartTime": {
+                            "S": "2022-03-28T19:26:04+0000"
+                        },
+                        "Metadata": {
+                            "S": "{}"
+                        },
+                        "Name": {
+                            "S": "RunGCHP"
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/benchmarks/dashboard/src/test_data/scan_results.json
+++ b/benchmarks/dashboard/src/test_data/scan_results.json
@@ -1,0 +1,967 @@
+{
+    "Items": [
+        {
+            "CreationDate": {
+                "S": "2022-03-24"
+            },
+            "ExecStatus": {
+                "S": "FAILED"
+            },
+            "S3Uri": {
+                "S": "s3://benchmarks-cloud/benchmarks/1Mon/gcc/gcc-1Mon-13.4.0-alpha.23.bd"
+            },
+            "Description": {
+                "S": "1Mon gcc benchmark simulation using '13.4.0-alpha.23'"
+            },
+            "InstanceID": {
+                "S": "gcc-1Mon-13.4.0-alpha.23.bd"
+            },
+            "Site": {
+                "S": "AWS"
+            }
+        },
+        {
+            "CreationDate": {
+                "S": "2022-03-17"
+            },
+            "ExecStatus": {
+                "S": "SUCCESSFUL"
+            },
+            "S3Uri": {
+                "S": "s3://benchmarks-cloud/benchmarks/1Hr/gchp/gchp-1Hr-d7f6e81.bd"
+            },
+            "Description": {
+                "S": "1Hr gchp benchmark simulation using 'd7f6e81'"
+            },
+            "InstanceID": {
+                "S": "gchp-1Hr-d7f6e81.bd"
+            },
+            "Site": {
+                "S": "AWS"
+            }
+        },
+        {
+            "CreationDate": {
+                "S": "2022-03-28"
+            },
+            "ExecStatus": {
+                "S": "SUCCESSFUL"
+            },
+            "S3Uri": {
+                "S": "s3://benchmarks-cloud/benchmarks/1Mon/gcc/gcc-1Mon-13.4.0-rc.3.bd"
+            },
+            "Description": {
+                "S": "1Mon gcc benchmark simulation using '13.4.0-rc.3'"
+            },
+            "InstanceID": {
+                "S": "gcc-1Mon-13.4.0-rc.3.bd"
+            },
+            "Site": {
+                "S": "AWS"
+            }
+        },
+        {
+            "CreationDate": {
+                "S": "2022-03-17"
+            },
+            "ExecStatus": {
+                "S": "SUCCESSFUL"
+            },
+            "S3Uri": {
+                "S": "s3://benchmarks-cloud/benchmarks/1Hr/gchp/gchp-1Hr-6817ca3.bd"
+            },
+            "Description": {
+                "S": "1Hr gchp benchmark simulation using '6817ca3'"
+            },
+            "InstanceID": {
+                "S": "gchp-1Hr-6817ca3.bd"
+            },
+            "Site": {
+                "S": "AWS"
+            }
+        },
+        {
+            "CreationDate": {
+                "S": "2022-03-22"
+            },
+            "ExecStatus": {
+                "S": "FAILED"
+            },
+            "S3Uri": {
+                "S": "s3://benchmarks-cloud/benchmarks/1Mon/gchp/gchp-1Mon-13.4.0-alpha.22.bd"
+            },
+            "Description": {
+                "S": "1Mon gchp benchmark simulation using '13.4.0-alpha.22'"
+            },
+            "InstanceID": {
+                "S": "gchp-1Mon-13.4.0-alpha.22.bd"
+            },
+            "Site": {
+                "S": "AWS"
+            }
+        },
+        {
+            "CreationDate": {
+                "S": "2022-03-17"
+            },
+            "ExecStatus": {
+                "S": "SUCCESSFUL"
+            },
+            "S3Uri": {
+                "S": "s3://benchmarks-cloud/benchmarks/1Hr/gchp/gchp-1Hr-f295a52.bd"
+            },
+            "Description": {
+                "S": "1Hr gchp benchmark simulation using 'f295a52'"
+            },
+            "InstanceID": {
+                "S": "gchp-1Hr-f295a52.bd"
+            },
+            "Site": {
+                "S": "AWS"
+            }
+        },
+        {
+            "CreationDate": {
+                "S": "2022-03-24"
+            },
+            "ExecStatus": {
+                "S": "FAILED"
+            },
+            "S3Uri": {
+                "S": "s3://benchmarks-cloud/benchmarks/1Hr/gcc/gcc-1Hr-f9a901a.bd"
+            },
+            "Description": {
+                "S": "1Hr gcc benchmark simulation using 'f9a901a'"
+            },
+            "InstanceID": {
+                "S": "gcc-1Hr-f9a901a.bd"
+            },
+            "Site": {
+                "S": "AWS"
+            }
+        },
+        {
+            "CreationDate": {
+                "S": "2022-03-24"
+            },
+            "ExecStatus": {
+                "S": "FAILED"
+            },
+            "S3Uri": {
+                "S": "s3://benchmarks-cloud/benchmarks/1Hr/gchp/gchp-1Hr-2a814f6.bd"
+            },
+            "Description": {
+                "S": "1Hr gchp benchmark simulation using '2a814f6'"
+            },
+            "InstanceID": {
+                "S": "gchp-1Hr-2a814f6.bd"
+            },
+            "Site": {
+                "S": "AWS"
+            }
+        },
+        {
+            "CreationDate": {
+                "S": "2022-03-24"
+            },
+            "ExecStatus": {
+                "S": "FAILED"
+            },
+            "S3Uri": {
+                "S": "s3://benchmarks-cloud/benchmarks/1Mon/gcc/gcc-1Mon-13.4.0-alpha.24.bd"
+            },
+            "Description": {
+                "S": "1Mon gcc benchmark simulation using '13.4.0-alpha.24'"
+            },
+            "InstanceID": {
+                "S": "gcc-1Mon-13.4.0-alpha.24.bd"
+            },
+            "Site": {
+                "S": "AWS"
+            }
+        },
+        {
+            "CreationDate": {
+                "S": "2022-03-17"
+            },
+            "ExecStatus": {
+                "S": "SUCCESSFUL"
+            },
+            "S3Uri": {
+                "S": "s3://benchmarks-cloud/benchmarks/1Mon/gcc/gcc-1Mon-13.4.0-alpha.20.bd"
+            },
+            "Description": {
+                "S": "1Mon gcc benchmark simulation using '13.4.0-alpha.20'"
+            },
+            "InstanceID": {
+                "S": "gcc-1Mon-13.4.0-alpha.20.bd"
+            },
+            "Site": {
+                "S": "AWS"
+            }
+        },
+        {
+            "CreationDate": {
+                "S": "2022-03-17"
+            },
+            "ExecStatus": {
+                "S": "SUCCESSFUL"
+            },
+            "S3Uri": {
+                "S": "s3://benchmarks-cloud/benchmarks/1Mon/gcc/gcc-1Mon-13.4.0-alpha.21.bd"
+            },
+            "Description": {
+                "S": "1Mon gcc benchmark simulation using '13.4.0-alpha.21'"
+            },
+            "InstanceID": {
+                "S": "gcc-1Mon-13.4.0-alpha.21.bd"
+            },
+            "Site": {
+                "S": "AWS"
+            }
+        },
+        {
+            "CreationDate": {
+                "S": "2022-03-28"
+            },
+            "ExecStatus": {
+                "S": "SUCCESSFUL"
+            },
+            "S3Uri": {
+                "S": "s3://benchmarks-cloud/benchmarks/1Mon/gchp/gchp-1Mon-13.4.0-rc.3.bd"
+            },
+            "Description": {
+                "S": "1Mon gchp benchmark simulation using '13.4.0-rc.3'"
+            },
+            "InstanceID": {
+                "S": "gchp-1Mon-13.4.0-rc.3.bd"
+            },
+            "Site": {
+                "S": "AWS"
+            }
+        },
+        {
+            "CreationDate": {
+                "S": "2022-03-17"
+            },
+            "ExecStatus": {
+                "S": "SUCCESSFUL"
+            },
+            "S3Uri": {
+                "S": "s3://benchmarks-cloud/benchmarks/1Hr/gcc/gcc-1Hr-483b659.bd"
+            },
+            "Description": {
+                "S": "1Hr gcc benchmark simulation using '483b659'"
+            },
+            "InstanceID": {
+                "S": "gcc-1Hr-483b659.bd"
+            },
+            "Site": {
+                "S": "AWS"
+            }
+        },
+        {
+            "CreationDate": {
+                "S": "2022-03-09"
+            },
+            "ExecStatus": {
+                "S": "SUCCESSFUL"
+            },
+            "S3Uri": {
+                "S": "s3://benchmarks-cloud/benchmarks/1Hr/gcc/gcc-1Hr-7131f3d.bd"
+            },
+            "Description": {
+                "S": "1Hr gcc benchmark simulation using '7131f3d'"
+            },
+            "InstanceID": {
+                "S": "gcc-1Hr-7131f3d.bd"
+            },
+            "Site": {
+                "S": "AWS"
+            }
+        },
+        {
+            "CreationDate": {
+                "S": "2022-03-22"
+            },
+            "ExecStatus": {
+                "S": "SUCCESSFUL"
+            },
+            "S3Uri": {
+                "S": "s3://benchmarks-cloud/benchmarks/1Hr/gcc/gcc-1Hr-d15d3c6.bd"
+            },
+            "Description": {
+                "S": "1Hr gcc benchmark simulation using 'd15d3c6'"
+            },
+            "InstanceID": {
+                "S": "gcc-1Hr-d15d3c6.bd"
+            },
+            "Site": {
+                "S": "AWS"
+            }
+        },
+        {
+            "CreationDate": {
+                "S": "2022-03-28"
+            },
+            "ExecStatus": {
+                "S": "SUCCESSFUL"
+            },
+            "S3Uri": {
+                "S": "s3://benchmarks-cloud/benchmarks/1Mon/gchp/gchp-1Mon-13.4.0-alpha.25.bd"
+            },
+            "Description": {
+                "S": "1Mon gchp benchmark simulation using '13.4.0-alpha.25'"
+            },
+            "InstanceID": {
+                "S": "gchp-1Mon-13.4.0-alpha.25.bd"
+            },
+            "Site": {
+                "S": "AWS"
+            }
+        },
+        {
+            "CreationDate": {
+                "S": "2022-03-24"
+            },
+            "ExecStatus": {
+                "S": "FAILED"
+            },
+            "S3Uri": {
+                "S": "s3://benchmarks-cloud/benchmarks/1Hr/gcc/gcc-1Hr-25e3809.bd"
+            },
+            "Description": {
+                "S": "1Hr gcc benchmark simulation using '25e3809'"
+            },
+            "InstanceID": {
+                "S": "gcc-1Hr-25e3809.bd"
+            },
+            "Site": {
+                "S": "AWS"
+            }
+        },
+        {
+            "CreationDate": {
+                "S": "2022-03-09"
+            },
+            "ExecStatus": {
+                "S": "SUCCESSFUL"
+            },
+            "S3Uri": {
+                "S": "s3://benchmarks-cloud/benchmarks/1Hr/gchp/gchp-1Hr-5d35275.bd"
+            },
+            "Description": {
+                "S": "1Hr gchp benchmark simulation using '5d35275'"
+            },
+            "InstanceID": {
+                "S": "gchp-1Hr-5d35275.bd"
+            },
+            "Site": {
+                "S": "AWS"
+            }
+        },
+        {
+            "CreationDate": {
+                "S": "2022-03-28"
+            },
+            "ExecStatus": {
+                "S": "SUCCESSFUL"
+            },
+            "S3Uri": {
+                "S": "s3://benchmarks-cloud/benchmarks/1Hr/gcc/gcc-1Hr-3f70328.bd"
+            },
+            "Description": {
+                "S": "1Hr gcc benchmark simulation using '3f70328'"
+            },
+            "InstanceID": {
+                "S": "gcc-1Hr-3f70328.bd"
+            },
+            "Site": {
+                "S": "AWS"
+            }
+        },
+        {
+            "CreationDate": {
+                "S": "2022-03-17"
+            },
+            "ExecStatus": {
+                "S": "SUCCESSFUL"
+            },
+            "S3Uri": {
+                "S": "s3://benchmarks-cloud/benchmarks/1Hr/gcc/gcc-1Hr-a6a4783.bd"
+            },
+            "Description": {
+                "S": "1Hr gcc benchmark simulation using 'a6a4783'"
+            },
+            "InstanceID": {
+                "S": "gcc-1Hr-a6a4783.bd"
+            },
+            "Site": {
+                "S": "AWS"
+            }
+        },
+        {
+            "CreationDate": {
+                "S": "2022-03-09"
+            },
+            "ExecStatus": {
+                "S": "SUCCESSFUL"
+            },
+            "S3Uri": {
+                "S": "s3://benchmarks-cloud/benchmarks/1Mon/gcc/gcc-1Mon-13.4.0-alpha.19.bd"
+            },
+            "Description": {
+                "S": "1Mon gcc benchmark simulation using '13.4.0-alpha.19'"
+            },
+            "InstanceID": {
+                "S": "gcc-1Mon-13.4.0-alpha.19.bd"
+            },
+            "Site": {
+                "S": "AWS"
+            }
+        },
+        {
+            "CreationDate": {
+                "S": "2022-03-18"
+            },
+            "ExecStatus": {
+                "S": "SUCCESSFUL"
+            },
+            "S3Uri": {
+                "S": "s3://benchmarks-cloud/benchmarks/1Hr/gcc/gcc-1Hr-44a05aa.bd"
+            },
+            "Description": {
+                "S": "1Hr gcc benchmark simulation using '44a05aa'"
+            },
+            "InstanceID": {
+                "S": "gcc-1Hr-44a05aa.bd"
+            },
+            "Site": {
+                "S": "AWS"
+            }
+        },
+        {
+            "CreationDate": {
+                "S": "2022-03-09"
+            },
+            "ExecStatus": {
+                "S": "SUCCESSFUL"
+            },
+            "S3Uri": {
+                "S": "s3://benchmarks-cloud/benchmarks/1Hr/gchp/gchp-1Hr-3b400ed.bd"
+            },
+            "Description": {
+                "S": "1Hr GCHP benchmark simulation using '3b400ed'"
+            },
+            "InstanceID": {
+                "S": "gchp-1Hr-3b400ed.bd"
+            },
+            "Site": {
+                "S": "AWS"
+            }
+        },
+        {
+            "CreationDate": {
+                "S": "2022-03-31"
+            },
+            "ExecStatus": {
+                "S": "SUCCESSFUL"
+            },
+            "S3Uri": {
+                "S": "s3://benchmarks-cloud/benchmarks/1Hr/gchp/gchp-1Hr-ef73756.bd"
+            },
+            "Description": {
+                "S": "1Hr gchp benchmark simulation using 'ef73756'"
+            },
+            "InstanceID": {
+                "S": "gchp-1Hr-ef73756.bd"
+            },
+            "Site": {
+                "S": "AWS"
+            }
+        },
+        {
+            "CreationDate": {
+                "S": "2022-03-18"
+            },
+            "ExecStatus": {
+                "S": "SUCCESSFUL"
+            },
+            "S3Uri": {
+                "S": "s3://benchmarks-cloud/benchmarks/1Hr/gchp/gchp-1Hr-47619e8.bd"
+            },
+            "Description": {
+                "S": "1Hr gchp benchmark simulation using '47619e8'"
+            },
+            "InstanceID": {
+                "S": "gchp-1Hr-47619e8.bd"
+            },
+            "Site": {
+                "S": "AWS"
+            }
+        },
+        {
+            "CreationDate": {
+                "S": "2022-03-08"
+            },
+            "ExecStatus": {
+                "S": "SUCCESSFUL"
+            },
+            "S3Uri": {
+                "S": "s3://benchmarks-cloud/benchmarks/1Hr/gcc/gcc-1Hr-404b4d9.bd"
+            },
+            "Description": {
+                "S": "1Hr GCC benchmark simulation using '404b4d9'"
+            },
+            "InstanceID": {
+                "S": "gcc-1Hr-404b4d9.bd"
+            },
+            "Site": {
+                "S": "AWS"
+            }
+        },
+        {
+            "CreationDate": {
+                "S": "2022-03-31"
+            },
+            "ExecStatus": {
+                "S": "FAILED"
+            },
+            "S3Uri": {
+                "S": "s3://benchmarks-cloud/plots/bmp.gchp-1Hr-ef73756.bd_gchp-1Hr-caa6320.bd"
+            },
+            "Description": {
+                "S": "GCHP benchmark plot creation (ref: 'gchp-1Hr-ef73756.bd'; dev:'gchp-1Hr-caa6320.bd')"
+            },
+            "InstanceID": {
+                "S": "bmp.gchp-1Hr-ef73756.bd_gchp-1Hr-caa6320.bd"
+            },
+            "Site": {
+                "S": "AWS"
+            }
+        },
+        {
+            "CreationDate": {
+                "S": "2022-03-17"
+            },
+            "ExecStatus": {
+                "S": "SUCCESSFUL"
+            },
+            "S3Uri": {
+                "S": "s3://benchmarks-cloud/benchmarks/1Hr/gcc/gcc-1Hr-172ae01.bd"
+            },
+            "Description": {
+                "S": "1Hr gcc benchmark simulation using '172ae01'"
+            },
+            "InstanceID": {
+                "S": "gcc-1Hr-172ae01.bd"
+            },
+            "Site": {
+                "S": "AWS"
+            }
+        },
+        {
+            "CreationDate": {
+                "S": "2022-03-09"
+            },
+            "ExecStatus": {
+                "S": "SUCCESSFUL"
+            },
+            "S3Uri": {
+                "S": "s3://benchmarks-cloud/benchmarks/1Mon/gchp/gchp-1Mon-13.4.0-alpha.19.bd"
+            },
+            "Description": {
+                "S": "1Mon gchp benchmark simulation using '13.4.0-alpha.19'"
+            },
+            "InstanceID": {
+                "S": "gchp-1Mon-13.4.0-alpha.19.bd"
+            },
+            "Site": {
+                "S": "AWS"
+            }
+        },
+        {
+            "CreationDate": {
+                "S": "2022-03-08"
+            },
+            "ExecStatus": {
+                "S": "SUCCESSFUL"
+            },
+            "S3Uri": {
+                "S": "s3://benchmarks-cloud/benchmarks/1Hr/gcc/gcc-1Hr-13.3.4.bd"
+            },
+            "Description": {
+                "S": "1Hr GCC benchmark simulation using '13.3.4'"
+            },
+            "InstanceID": {
+                "S": "gcc-1Hr-13.3.4.bd"
+            },
+            "Site": {
+                "S": "AWS"
+            }
+        },
+        {
+            "CreationDate": {
+                "S": "2022-03-31"
+            },
+            "ExecStatus": {
+                "S": "SUCCESSFUL"
+            },
+            "S3Uri": {
+                "S": "s3://benchmarks-cloud/benchmarks/1Hr/gchp/gchp-1Hr-caa6320.bd"
+            },
+            "Description": {
+                "S": "1Hr gchp benchmark simulation using 'caa6320'"
+            },
+            "InstanceID": {
+                "S": "gchp-1Hr-caa6320.bd"
+            },
+            "Site": {
+                "S": "AWS"
+            }
+        },
+        {
+            "CreationDate": {
+                "S": "2022-03-16"
+            },
+            "ExecStatus": {
+                "S": "SUCCESSFUL"
+            },
+            "S3Uri": {
+                "S": "s3://benchmarks-cloud/benchmarks/1Hr/gchp/gchp-1Hr-552323b.bd"
+            },
+            "Description": {
+                "S": "1Hr gchp benchmark simulation using '552323b'"
+            },
+            "InstanceID": {
+                "S": "gchp-1Hr-552323b.bd"
+            },
+            "Site": {
+                "S": "AWS"
+            }
+        },
+        {
+            "CreationDate": {
+                "S": "2022-03-17"
+            },
+            "ExecStatus": {
+                "S": "SUCCESSFUL"
+            },
+            "S3Uri": {
+                "S": "s3://benchmarks-cloud/benchmarks/1Mon/gchp/gchp-1Mon-13.4.0-alpha.20.bd"
+            },
+            "Description": {
+                "S": "1Mon gchp benchmark simulation using '13.4.0-alpha.20'"
+            },
+            "InstanceID": {
+                "S": "gchp-1Mon-13.4.0-alpha.20.bd"
+            },
+            "Site": {
+                "S": "AWS"
+            }
+        },
+        {
+            "CreationDate": {
+                "S": "2022-03-24"
+            },
+            "ExecStatus": {
+                "S": "FAILED"
+            },
+            "S3Uri": {
+                "S": "s3://benchmarks-cloud/benchmarks/1Hr/gchp/gchp-1Hr-9da5a3f.bd"
+            },
+            "Description": {
+                "S": "1Hr gchp benchmark simulation using '9da5a3f'"
+            },
+            "InstanceID": {
+                "S": "gchp-1Hr-9da5a3f.bd"
+            },
+            "Site": {
+                "S": "AWS"
+            }
+        },
+        {
+            "CreationDate": {
+                "S": "2022-03-08"
+            },
+            "ExecStatus": {
+                "S": "SUCCESSFUL"
+            },
+            "S3Uri": {
+                "S": "s3://benchmarks-cloud/benchmarks/1Hr/gcc/gcc-1Hr-fd28642.bd"
+            },
+            "Description": {
+                "S": "1Hr GCC benchmark simulation using 'fd28642'"
+            },
+            "InstanceID": {
+                "S": "gcc-1Hr-fd28642.bd"
+            },
+            "Site": {
+                "S": "AWS"
+            }
+        },
+        {
+            "CreationDate": {
+                "S": "2022-03-28"
+            },
+            "ExecStatus": {
+                "S": "SUCCESSFUL"
+            },
+            "S3Uri": {
+                "S": "s3://benchmarks-cloud/benchmarks/1Mon/gcc/gcc-1Mon-13.4.0-alpha.25.bd"
+            },
+            "Description": {
+                "S": "1Mon gcc benchmark simulation using '13.4.0-alpha.25'"
+            },
+            "InstanceID": {
+                "S": "gcc-1Mon-13.4.0-alpha.25.bd"
+            },
+            "Site": {
+                "S": "AWS"
+            }
+        },
+        {
+            "CreationDate": {
+                "S": "2022-03-24"
+            },
+            "ExecStatus": {
+                "S": "SUCCESSFUL"
+            },
+            "S3Uri": {
+                "S": "s3://benchmarks-cloud/benchmarks/1Mon/gchp/gchp-1Mon-13.4.0-alpha.23.bd"
+            },
+            "Description": {
+                "S": "1Mon gchp benchmark simulation using '13.4.0-alpha.23'"
+            },
+            "InstanceID": {
+                "S": "gchp-1Mon-13.4.0-alpha.23.bd"
+            },
+            "Site": {
+                "S": "AWS"
+            }
+        },
+        {
+            "CreationDate": {
+                "S": "2022-03-08"
+            },
+            "ExecStatus": {
+                "S": "SUCCESSFUL"
+            },
+            "S3Uri": {
+                "S": "s3://benchmarks-cloud/benchmarks/1Hr/gchp/gchp-1Hr-13.3.4.bd"
+            },
+            "Description": {
+                "S": "1Hr GCHP benchmark simulation using '13.3.4'"
+            },
+            "InstanceID": {
+                "S": "gchp-1Hr-13.3.4.bd"
+            },
+            "Site": {
+                "S": "AWS"
+            }
+        },
+        {
+            "CreationDate": {
+                "S": "2022-03-17"
+            },
+            "ExecStatus": {
+                "S": "FAILED"
+            },
+            "S3Uri": {
+                "S": "s3://benchmarks-cloud/benchmarks/1Mon/gchp/gchp-1Mon-13.4.0-alpha.21.bd"
+            },
+            "Description": {
+                "S": "1Mon gchp benchmark simulation using '13.4.0-alpha.21'"
+            },
+            "InstanceID": {
+                "S": "gchp-1Mon-13.4.0-alpha.21.bd"
+            },
+            "Site": {
+                "S": "AWS"
+            }
+        },
+        {
+            "CreationDate": {
+                "S": "2022-03-30"
+            },
+            "ExecStatus": {
+                "S": "IN_PROGRESS"
+            },
+            "S3Uri": {
+                "S": "s3://benchmarks-cloud/benchmarks/1Hr/gchp/gchp-1Hr-13.2.1.bd"
+            },
+            "Description": {
+                "S": "1Hr gchp benchmark simulation using '13.2.1'"
+            },
+            "InstanceID": {
+                "S": "gchp-1Hr-13.2.1.bd"
+            },
+            "Site": {
+                "S": "AWS"
+            }
+        },
+        {
+            "CreationDate": {
+                "S": "2022-03-09"
+            },
+            "ExecStatus": {
+                "S": "SUCCESSFUL"
+            },
+            "S3Uri": {
+                "S": "s3://benchmarks-cloud/benchmarks/1Hr/gcc/gcc-1Hr-447fc29.bd"
+            },
+            "Description": {
+                "S": "1Hr gcc benchmark simulation using '447fc29'"
+            },
+            "InstanceID": {
+                "S": "gcc-1Hr-447fc29.bd"
+            },
+            "Site": {
+                "S": "AWS"
+            }
+        },
+        {
+            "CreationDate": {
+                "S": "2022-03-22"
+            },
+            "ExecStatus": {
+                "S": "SUCCESSFUL"
+            },
+            "S3Uri": {
+                "S": "s3://benchmarks-cloud/benchmarks/1Hr/gchp/gchp-1Hr-2f037c2.bd"
+            },
+            "Description": {
+                "S": "1Hr gchp benchmark simulation using '2f037c2'"
+            },
+            "InstanceID": {
+                "S": "gchp-1Hr-2f037c2.bd"
+            },
+            "Site": {
+                "S": "AWS"
+            }
+        },
+        {
+            "CreationDate": {
+                "S": "2022-03-24"
+            },
+            "ExecStatus": {
+                "S": "FAILED"
+            },
+            "S3Uri": {
+                "S": "s3://benchmarks-cloud/benchmarks/1Mon/gchp/gchp-1Mon-13.4.0-alpha.24.bd"
+            },
+            "Description": {
+                "S": "1Mon gchp benchmark simulation using '13.4.0-alpha.24'"
+            },
+            "InstanceID": {
+                "S": "gchp-1Mon-13.4.0-alpha.24.bd"
+            },
+            "Site": {
+                "S": "AWS"
+            }
+        },
+        {
+            "CreationDate": {
+                "S": "2022-03-18"
+            },
+            "ExecStatus": {
+                "S": "SUCCESSFUL"
+            },
+            "S3Uri": {
+                "S": "s3://benchmarks-cloud/benchmarks/1Hr/gchp/gchp-1Hr-519b9bd.bd"
+            },
+            "Description": {
+                "S": "1Hr gchp benchmark simulation using '519b9bd'"
+            },
+            "InstanceID": {
+                "S": "gchp-1Hr-519b9bd.bd"
+            },
+            "Site": {
+                "S": "AWS"
+            }
+        },
+        {
+            "CreationDate": {
+                "S": "2022-03-09"
+            },
+            "ExecStatus": {
+                "S": "SUCCESSFUL"
+            },
+            "S3Uri": {
+                "S": "s3://benchmarks-cloud/benchmarks/1Hr/gchp/gchp-1Hr-1ea41cd.bd"
+            },
+            "Description": {
+                "S": "1Hr gchp benchmark simulation using '1ea41cd'"
+            },
+            "InstanceID": {
+                "S": "gchp-1Hr-1ea41cd.bd"
+            },
+            "Site": {
+                "S": "AWS"
+            }
+        },
+        {
+            "CreationDate": {
+                "S": "2022-03-18"
+            },
+            "ExecStatus": {
+                "S": "SUCCESSFUL"
+            },
+            "S3Uri": {
+                "S": "s3://benchmarks-cloud/benchmarks/1Hr/gcc/gcc-1Hr-60a412b.bd"
+            },
+            "Description": {
+                "S": "1Hr gcc benchmark simulation using '60a412b'"
+            },
+            "InstanceID": {
+                "S": "gcc-1Hr-60a412b.bd"
+            },
+            "Site": {
+                "S": "AWS"
+            }
+        },
+        {
+            "CreationDate": {
+                "S": "2022-03-22"
+            },
+            "ExecStatus": {
+                "S": "SUCCESSFUL"
+            },
+            "S3Uri": {
+                "S": "s3://benchmarks-cloud/benchmarks/1Mon/gcc/gcc-1Mon-13.4.0-alpha.22.bd"
+            },
+            "Description": {
+                "S": "1Mon gcc benchmark simulation using '13.4.0-alpha.22'"
+            },
+            "InstanceID": {
+                "S": "gcc-1Mon-13.4.0-alpha.22.bd"
+            },
+            "Site": {
+                "S": "AWS"
+            }
+        },
+        {
+            "CreationDate": {
+                "S": "2022-03-18"
+            },
+            "ExecStatus": {
+                "S": "SUCCESSFUL"
+            },
+            "S3Uri": {
+                "S": "s3://benchmarks-cloud/benchmarks/1Hr/gcc/gcc-1Hr-f2a6715.bd"
+            },
+            "Description": {
+                "S": "1Hr gcc benchmark simulation using 'f2a6715'"
+            },
+            "InstanceID": {
+                "S": "gcc-1Hr-f2a6715.bd"
+            },
+            "Site": {
+                "S": "AWS"
+            }
+        }
+    ],
+    "Count": 48,
+    "ScannedCount": 48,
+    "ConsumedCapacity": null
+}

--- a/deploy/environments/harvard/.terraform.lock.hcl
+++ b/deploy/environments/harvard/.terraform.lock.hcl
@@ -1,22 +1,41 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
-provider "registry.terraform.io/hashicorp/aws" {
-  version     = "3.63.0"
-  constraints = "3.63.0"
+provider "registry.terraform.io/hashicorp/archive" {
+  version = "2.2.0"
   hashes = [
-    "h1:Z+2GvXLgqQ/uPMH8dv+dXJ/t+jd6sriYjhCJS6kSO6g=",
-    "zh:42c6c98b294953a4e1434a331251e539f5372bf6779bd61ab5df84cac0545287",
-    "zh:5493773762a470889c9a23db97582d3a82035847c8d3bd13323b4c3012abf325",
-    "zh:550d22ff9fed4d817a922e7b84bd9d1f2ef8d3afa00832cf66b8cd5f0e6dc748",
-    "zh:632cb5e2d9d5041875f57174236eafe5b05dbf26750c1041ab57eb08c5369fe2",
-    "zh:7cfeaf5bde1b28bd010415af1f3dc494680a8374f1a26ec19db494d99938cc4e",
-    "zh:99d871606b67c8aefce49007315de15736b949c09a9f8f29ad8af1e9ce383ed3",
-    "zh:c4fc8539ffe90df5c7ae587fde495fac6bc0186fec2f2713a8988a619cef265f",
-    "zh:d0a26493206575c99ca221d78fe64f96a8fbcebe933af92eea6b39168c1f1c1d",
-    "zh:e156fdc964fdd4a7586ec15629e20d2b06295b46b4962428006e088145db07d6",
-    "zh:eb04fc80f652b5c92f76822f0fec1697581543806244068506aed69e1bb9b2af",
-    "zh:f5638a533cf9444f7d02b5527446cdbc3b2eab8bcc4ec4b0ca32035fe6f479d3",
+    "h1:2K5LQkuWRS2YN1/YoNaHn9MAzjuTX8Gaqy6i8Mbfv8Y=",
+    "zh:06bd875932288f235c16e2237142b493c2c2b6aba0e82e8c85068332a8d2a29e",
+    "zh:0c681b481372afcaefddacc7ccdf1d3bb3a0c0d4678a526bc8b02d0c331479bc",
+    "zh:100fc5b3fc01ea463533d7bbfb01cb7113947a969a4ec12e27f5b2be49884d6c",
+    "zh:55c0d7ddddbd0a46d57c51fcfa9b91f14eed081a45101dbfc7fd9d2278aa1403",
+    "zh:73a5dd68379119167934c48afa1101b09abad2deb436cd5c446733e705869d6b",
+    "zh:841fc4ac6dc3479981330974d44ad2341deada8a5ff9e3b1b4510702dfbdbed9",
+    "zh:91be62c9b41edb137f7f835491183628d484e9d6efa82fcb75cfa538c92791c5",
+    "zh:acd5f442bd88d67eb948b18dc2ed421c6c3faee62d3a12200e442bfff0aa7d8b",
+    "zh:ad5720da5524641ad718a565694821be5f61f68f1c3c5d2cfa24426b8e774bef",
+    "zh:e63f12ea938520b3f83634fc29da28d92eed5cfbc5cc8ca08281a6a9c36cca65",
+    "zh:f6542918faa115df46474a36aabb4c3899650bea036b5f8a5e296be6f8f25767",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.15.0"
+  constraints = ">= 4.15.0"
+  hashes = [
+    "h1:naW0xGOUXq+OX+b8KLToVXvD8VA4FRWg2UP/cvTvRec=",
+    "zh:005a4b78becbcf5ead8c0bf0a3b7b3c17990f4d030951948088ff9f9867e192f",
+    "zh:21c2cf1de303d6bd83d11a11966ec2553ccfd27166a6bcec9f67a4d69af1e8aa",
+    "zh:22c43c99e8140654dd84a25183c5d5ba92a0b7524573bba11950d3dc59ac6846",
+    "zh:4da4fa8dd7689c84b712b743084ad5483fd0b20b97bf43eff8eede9dcffd3751",
+    "zh:532b297b3fa0c5dddc1603d755b27d7bf952eb639177b66c7ea5e5ca328a37cf",
+    "zh:6681db82e988ffd1880993494d191b98a1bf89ad6aa39727d838fd3720227bf8",
+    "zh:8adf567cc3b787e8400eeb5da0c3057123d67cf06055b76018947109596e2605",
+    "zh:8fbc009feed7b58a5bed6d36fe4fbcf093537cc406cd61b7a5ae452f292f6302",
+    "zh:912040f3a60da22622eabdd0c295c3bff1de98606ab559c4d9020196604a33b8",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:d95b42e326574ec35dc44785fbe5a716ff4b0593c42e9e20fc4598d913082516",
+    "zh:f7e1733dc990524420d4ac027c581cf40e6c4751aaf7dd2c9da19dc473d741a5",
   ]
 }
 

--- a/deploy/environments/harvard/.terraform.lock.hcl
+++ b/deploy/environments/harvard/.terraform.lock.hcl
@@ -39,6 +39,26 @@ provider "registry.terraform.io/hashicorp/aws" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/null" {
+  version     = "3.1.1"
+  constraints = "~> 3.1.1"
+  hashes = [
+    "h1:Pctug/s/2Hg5FJqjYcTM0kPyx3AoYK1MpRWO0T9V2ns=",
+    "zh:063466f41f1d9fd0dd93722840c1314f046d8760b1812fa67c34de0afcba5597",
+    "zh:08c058e367de6debdad35fc24d97131c7cf75103baec8279aba3506a08b53faf",
+    "zh:73ce6dff935150d6ddc6ac4a10071e02647d10175c173cfe5dca81f3d13d8afe",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:8fdd792a626413502e68c195f2097352bdc6a0df694f7df350ed784741eb587e",
+    "zh:976bbaf268cb497400fd5b3c774d218f3933271864345f18deebe4dcbfcd6afa",
+    "zh:b21b78ca581f98f4cdb7a366b03ae9db23a73dfa7df12c533d7c19b68e9e72e5",
+    "zh:b7fc0c1615dbdb1d6fd4abb9c7dc7da286631f7ca2299fb9cd4664258ccfbff4",
+    "zh:d1efc942b2c44345e0c29bc976594cb7278c38cfb8897b344669eafbc3cddf46",
+    "zh:e356c245b3cd9d4789bab010893566acace682d7db877e52d40fc4ca34a50924",
+    "zh:ea98802ba92fcfa8cf12cbce2e9e7ebe999afbf8ed47fa45fc847a098d89468b",
+    "zh:eff8872458806499889f6927b5d954560f3d74bf20b6043409edf94d26cd906f",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/template" {
   version = "2.2.0"
   hashes = [

--- a/deploy/main.tf
+++ b/deploy/main.tf
@@ -408,3 +408,13 @@ module "aws_marketplace" {
   source      = "./modules/marketplace"
   count       = local.only_harvard
 }
+module "gc_testing_dashboard" {
+  source      = "./modules/lambda"
+  count       = local.only_harvard
+  name_prefix = "gc-testing-dashboard"
+  handler     = "geoschem_testing.handler"
+  code_path   = "../../../benchmarks/dashboard/src"
+  packages_path  = "../../../benchmarks/dashboard/packages"
+  enable_lambda_function_url = true
+  additional_role_permissions = ["arn:aws:iam::aws:policy/AmazonDynamoDBReadOnlyAccess"]
+}

--- a/deploy/main.tf
+++ b/deploy/main.tf
@@ -402,3 +402,8 @@ module "washu_iam_role" {
 }
 EOF
 }
+
+module "aws_marketplace" {
+  source      = "./modules/marketplace"
+  count       = local.only_harvard
+}

--- a/deploy/main.tf
+++ b/deploy/main.tf
@@ -13,7 +13,7 @@ terraform {
   required_version = ">= 1.0.5" # at least have v1.0.5 of terraform
   required_providers {
     aws = {
-      version = ">= 3.63.0" # at least have v3.56.0 of aws provider
+      version = ">= 4.15.0" # at least have v3.56.0 of aws provider
       source  = "hashicorp/aws"
     }
   }
@@ -37,8 +37,11 @@ locals {
 data "aws_vpc" "default" { # fetch default vpc
   default = true
 }
-data "aws_subnet_ids" "all_default_subnets" { # fetch default subnets
-  vpc_id = data.aws_vpc.default.id
+data "aws_subnets" "all_default_subnets" { # fetch default subnets
+  filter {
+    name = "vpc-id"
+    values = [data.aws_vpc.default.id]
+  }
 }
 module "default_security_group" {
   count       = local.all_environments
@@ -64,7 +67,6 @@ module "benchmarks_bucket" {
   count             = local.all_environments
   bucket_name       = var.benchmarks_bucket
   bucket_acl        = "private"
-  enable_versioning = false
   expiration_settings = [{
     prefix = "benchmarks/1Day/"
     days   = 90
@@ -226,7 +228,7 @@ module "gchp_image_builder" {
   builder_version    = "1.0.2" # TODO: figure out a way to stop needing to change this with every update 
   component_file     = "../../modules/ec2-image-builder/components/install-spack-component.yaml"
   security_group_id  = module.default_security_group[0].security_group_id
-  subnet_id          = tolist(data.aws_subnet_ids.all_default_subnets.ids)[0]
+  subnet_id          = tolist(data.aws_subnets.all_default_subnets.ids)[0]
   recipe_name        = "geoschem_deps-pcluster_ami-x86_64-alinux2-intel_latest-intelmpi_latest"
 }
 
@@ -237,7 +239,6 @@ module "AQACF_bucket" {
   source            = "./modules/s3/bucket"
   count             = local.only_washu
   bucket_name       = "${var.organization}-aqacf-data"
-  enable_versioning = false
   bucket_policy     = <<POLICY
 {
    "Version": "2012-10-17",

--- a/deploy/modules/benchmarks/benchmarks-module.tf
+++ b/deploy/modules/benchmarks/benchmarks-module.tf
@@ -4,8 +4,11 @@
 data "aws_vpc" "default" {# fetch default vpc
   default = true
 }
-data "aws_subnet_ids" "subnets" {
-  vpc_id = local.vpc_id
+data "aws_subnets" "subnets" {
+  filter {
+    name = "vpc-id"
+    values = [local.vpc_id] 
+  }
 }
 # conditionally set whether to use the default vpc or a purpose built vpc
 locals {
@@ -52,7 +55,7 @@ module "plotting_step_function" {
 module "benchmarks_on_demand" {
   source                    = "../batch"
   name_prefix               = var.name_prefix
-  subnet_ids                = data.aws_subnet_ids.subnets.ids
+  subnet_ids                = data.aws_subnets.subnets.ids
   ami_id                    = var.ami_id
   instance_types            = var.instance_types
   security_group_id         = module.benchmarks_security_group.security_group_id
@@ -82,7 +85,7 @@ module "benchmarks_on_demand" {
 module "benchmarks_spot" {
   source                    = "../batch"
   name_prefix               = "${var.name_prefix}-spot"
-  subnet_ids                = data.aws_subnet_ids.subnets.ids
+  subnet_ids                = data.aws_subnets.subnets.ids
   ami_id                    = var.ami_id
   instance_types            = var.instance_types
   security_group_id         = module.benchmarks_security_group.security_group_id

--- a/deploy/modules/benchmarks/outputs.tf
+++ b/deploy/modules/benchmarks/outputs.tf
@@ -5,5 +5,5 @@ output "security_group_id" {
   value = module.benchmarks_security_group.security_group_id
 }
 output "subnet_ids" {
-  value = data.aws_subnet_ids.subnets.ids
+  value = data.aws_subnets.subnets.ids
 }

--- a/deploy/modules/lambda/lambda-module.tf
+++ b/deploy/modules/lambda/lambda-module.tf
@@ -1,0 +1,42 @@
+data "archive_file" "zip_code" {
+  type        = "zip"
+  source_dir  = var.code_path
+  output_path = "${var.packages_path}/code_pkg.zip"
+}
+
+data "archive_file" "zip_layers" {
+  type        = "zip"
+  source_dir  = "${var.packages_path}/layers"
+  output_path = "${var.packages_path}/layers.zip"
+}
+
+resource "aws_lambda_function" "lambda_function" {
+  filename         = data.archive_file.zip_code.output_path
+  function_name    = "${var.name_prefix}-function"
+  role             = aws_iam_role.lambda_role.arn
+  handler          = var.handler
+  layers           = [aws_lambda_layer_version.lambda_layer.arn]
+  source_code_hash = data.archive_file.zip_code.output_base64sha256
+  runtime          = var.runtime
+}
+
+resource "aws_lambda_function_url" "lambda_url" {
+  count              = var.enable_lambda_function_url == true ? 1 : 0
+  function_name      = aws_lambda_function.lambda_function.function_name
+  authorization_type = var.function_url_authentication
+  cors {
+    allow_origins = ["*"]
+    allow_methods = var.allow_methods
+  }
+}
+
+resource "aws_cloudwatch_log_group" "cloudwatch_logs" {
+  name              = "/aws/lambda/${aws_lambda_function.lambda_function.function_name}"
+  retention_in_days = var.log_expiration_days
+}
+
+resource "aws_lambda_layer_version" "lambda_layer" {
+  filename            = data.archive_file.zip_layers.output_path
+  layer_name          = "${var.name_prefix}-layer"
+  compatible_runtimes = [var.runtime]
+}

--- a/deploy/modules/lambda/lambda-roles.tf
+++ b/deploy/modules/lambda/lambda-roles.tf
@@ -1,0 +1,54 @@
+resource "aws_iam_role" "lambda_role" {
+  name = "${var.name_prefix}-role"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_policy" "lambda_policy" {
+  name        = "aws_iam_policy_for_terraform_aws_lambda_role"
+  path        = "/"
+  description = "AWS IAM Policy for managing aws lambda role"
+  policy      = <<EOF
+{
+ "Version": "2012-10-17",
+ "Statement": [
+   {
+     "Action": [
+       "logs:CreateLogGroup",
+       "logs:CreateLogStream",
+       "logs:PutLogEvents"
+     ],
+     "Resource": "arn:aws:logs:*:*:*",
+     "Effect": "Allow"
+   }
+ ]
+}
+EOF
+}
+resource "aws_iam_role_policy_attachment" "attach_iam_logs_policy" {
+  role       = aws_iam_role.lambda_role.name
+  policy_arn = aws_iam_policy.lambda_policy.arn
+}
+resource "aws_iam_role_policy_attachment" "attach_iam_lambda_policy" {
+  role       = aws_iam_role.lambda_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+resource "aws_iam_role_policy_attachment" "attach_iam_dynamo_policy" {
+  count      = length(var.additional_role_permissions)
+  role       = aws_iam_role.lambda_role.name
+  policy_arn = var.additional_role_permissions[count.index]
+}

--- a/deploy/modules/lambda/variables.tf
+++ b/deploy/modules/lambda/variables.tf
@@ -1,0 +1,36 @@
+variable "name_prefix" {
+  description = "name prefix used for lambda function and related resources"
+}
+variable "handler" {
+  description = "entrypoint for the lambda function"
+}
+variable "code_path" {
+  description = "path to source code dir"
+}
+variable "runtime" {
+  description = "lambda function runtime (eg. python3.9)"
+  default     = "python3.9"
+}
+variable "packages_path" {
+  description = "path to python packages needed to run code (remember to package it)"
+}
+variable "enable_lambda_function_url" {
+  description = "whether to create lambda function url"
+  default     = false
+}
+variable "allow_methods" {
+  description = "which api methods to allow (eg. [GET, POST, DELETE])"
+  default     = ["GET"]
+}
+variable "function_url_authentication" {
+  description = "type of authentication needed to access lambda url"
+  default     = "NONE"
+}
+variable "additional_role_permissions" {
+  description = "list of arns for additional permission policies function needs"
+  default     = []
+}
+variable "log_expiration_days" {
+  description = "number of days logs expire in"
+  default     = 14
+}

--- a/deploy/modules/marketplace/role.tf
+++ b/deploy/modules/marketplace/role.tf
@@ -1,0 +1,23 @@
+resource "aws_iam_role" "marketplace_role" {
+    name = "aws-marketplace-role"
+    assume_role_policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "",
+            "Effect": "Allow",
+            "Principal": {
+                "Service": "assets.marketplace.amazonaws.com"
+            },
+            "Action": "sts:AssumeRole"
+        }
+    ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_task_policy" {
+    role = aws_iam_role.marketplace_role.name
+    policy_arn = "arn:aws:iam::aws:policy/AWSMarketplaceAmiIngestion"
+}

--- a/deploy/modules/s3/bucket/s3-module.tf
+++ b/deploy/modules/s3/bucket/s3-module.tf
@@ -1,32 +1,50 @@
 resource "aws_s3_bucket" "bucket" {
     bucket = var.bucket_name
+}
 
-    acl = var.bucket_acl
+resource "aws_s3_bucket_policy" "policy" {
+    count = var.bucket_policy != null ? 1 : 0
+    bucket = aws_s3_bucket.bucket.id
     policy = var.bucket_policy
-    versioning {
-        enabled = var.enable_versioning
-    }
+}
 
-    dynamic "lifecycle_rule" {
-        for_each = var.expiration_settings
-        content {
-            enabled = true
-            prefix = lifecycle_rule.value["prefix"]
-            expiration {
-                days = lifecycle_rule.value["days"]
-            }
+resource "aws_s3_bucket_acl" "bucket_acl" {
+    bucket = aws_s3_bucket.bucket.id
+    acl    = var.bucket_acl
+}
+
+resource "aws_s3_bucket_versioning" "versioning" {
+  bucket = aws_s3_bucket.bucket.id
+  versioning_configuration {
+    status = var.enable_versioning
+  }
+}
+
+# conditionally add encryption if encryption algorithm is given
+resource "aws_s3_bucket_server_side_encryption_configuration" "encryption" {
+    count = var.encryption_algorithm != null ? 1 : 0
+    bucket = aws_s3_bucket.bucket.id
+    rule {
+        apply_server_side_encryption_by_default {
+            sse_algorithm = var.encryption_algorithm
         }
     }
-    # conditionally add encryption if encryption algorithm is given
-    dynamic "server_side_encryption_configuration" {
-        for_each = var.encryption_algorithm
+}
 
+# conditionally add lifecycle rule to bucket items
+resource "aws_s3_bucket_lifecycle_configuration" "lifecycle_rules" {
+  bucket = aws_s3_bucket.bucket.id
+    dynamic "rule" {
+        for_each = var.expiration_settings
         content {
-            rule {
-                apply_server_side_encryption_by_default {
-                    sse_algorithm = server_side_encryption_configuration.value
-                }
+            id = "rule-${index(var.expiration_settings, rule.value)}"
+            expiration {
+                days = rule.value["days"]
             }
+            filter {
+                prefix = rule.value["prefix"]
+            }
+            status = "Enabled"
         }
     }
 }

--- a/deploy/modules/s3/bucket/variables.tf
+++ b/deploy/modules/s3/bucket/variables.tf
@@ -12,12 +12,13 @@ variable bucket_policy {
 }
 
 variable enable_versioning {
-    description = "set to true to ensure you can see the full revision history of bucket objects"
+    default = "Suspended"
+    description = "set to Enabled to ensure you can see the full revision history of bucket objects"
 }
 
 variable encryption_algorithm {
     description = "set array to either [\"AES256\"] or [\"aws:kms\"] to enable server-side encryption for the bucket"
-    default = []
+    default = null
 }
 variable expiration_settings {
     description = "settings for object expiration in the bucket. Each object in array must contain a prefix and days attribute"

--- a/deploy/modules/terraform-state/terraform-state-module.tf
+++ b/deploy/modules/terraform-state/terraform-state-module.tf
@@ -3,8 +3,8 @@ module "state_bucket" {
     
     bucket_name = var.bucket_name
     bucket_acl = "private"
-    enable_versioning = true
-    encryption_algorithm = ["AES256"]
+    enable_versioning = "Enabled"
+    encryption_algorithm = "AES256"
 }
 
 module "state_lock_table" {


### PR DESCRIPTION
This pr moves the gc testing dashboard infrastructure from the aws-sam-cli to terraform, adds basic filtering functionality, and instead of having 3 separate lambda functions unifies them into a single lambda function with a single handler that navigates requests accordingly.