### PR TITLE
feature: add model type filters for gchp and gcc

### DIFF
--- a/dashboard/src/helpers/utilities.py
+++ b/dashboard/src/helpers/utilities.py
@@ -34,22 +34,48 @@ def apply_filters(event, entries):
             if "1Hr" in event["queryStringParameters"]
             else None
         )
-        monthly_filter = (
+        month_filter = (
             event["queryStringParameters"]["1Mon"]
             if "1Mon" in event["queryStringParameters"]
             else None
         )
+        gchp_filter = (
+            event["queryStringParameters"]["GCHP"]
+            if "GCHP" in event["queryStringParameters"]
+            else None
+        )
+        gcc_filter = (
+            event["queryStringParameters"]["GCC"]
+            if "GCC" in event["queryStringParameters"]
+            else None
+        )
 
-        if not (hour_filter and monthly_filter):
-            time_period = hour_filter or monthly_filter or None
-            entries = [
-                entry
-                for entry in entries
-                if entry.primary_key_classification.time_period == time_period
-            ]
+        entries = apply_time_filters(entries, hour_filter, month_filter)
+        entries = apply_model_filters(entries, gcc_filter, gchp_filter)
+
         if search_string != "":
             entries = [entry for entry in entries if search_string in entry.primary_key]
 
+    return entries
+
+def apply_time_filters(entries, hour_filter, month_filter):
+    if not (hour_filter and month_filter):
+        time_period = hour_filter or month_filter or None
+        entries = [
+            entry
+            for entry in entries
+            if entry.primary_key_classification.time_period == time_period
+        ]
+    return entries
+
+def apply_model_filters(entries, gcc_filter, gchp_filter):
+    if not (gcc_filter and gchp_filter):
+        model_type = gcc_filter or gchp_filter or None
+        entries = [
+            entry
+            for entry in entries
+            if (model_type is not None) and (model_type in entry.primary_key.upper())
+        ]
     return entries
 
 

--- a/dashboard/src/templates/testing-dashboard.html
+++ b/dashboard/src/templates/testing-dashboard.html
@@ -9,6 +9,8 @@
         size="25" />
         <input type="checkbox" id="hr-checkbox" name="1Hr" value="1Hr" checked><label for="hr-checkbox"> 1Hr </label>
         <input type="checkbox" id="mon-checkbox" name="1Mon" value="1Mon" checked><label for="mon-checkbox"> 1Mon </label>
+        <input type="checkbox" id="gchp-checkbox" name="GCHP" value="GCHP" checked><label for="gchp-checkbox"> gchp </label>
+        <input type="checkbox" id="gcc-checkbox" name="GCC" value="GCC" checked><label for="gcc-checkbox"> gcc </label>
         <input type="submit" value="Submit" />
     </form>
 </div>


### PR DESCRIPTION
This PR allows you to select only primary keys that include "gchp" or "gcc".